### PR TITLE
Change Illuminate\Foundation\Composer to Illuminate\Support\Composer …

### DIFF
--- a/src/Commands/API/APIControllerGeneratorCommand.php
+++ b/src/Commands/API/APIControllerGeneratorCommand.php
@@ -2,7 +2,7 @@
 
 namespace InfyOm\Generator\Commands\API;
 
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use InfyOm\Generator\Commands\BaseCommand;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\API\APIControllerGenerator;

--- a/src/Commands/API/APIGeneratorCommand.php
+++ b/src/Commands/API/APIGeneratorCommand.php
@@ -2,7 +2,7 @@
 
 namespace InfyOm\Generator\Commands\API;
 
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use InfyOm\Generator\Commands\BaseCommand;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\API\APIControllerGenerator;

--- a/src/Commands/API/APIRequestsGeneratorCommand.php
+++ b/src/Commands/API/APIRequestsGeneratorCommand.php
@@ -2,7 +2,7 @@
 
 namespace InfyOm\Generator\Commands\API;
 
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use InfyOm\Generator\Commands\BaseCommand;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\API\APIRequestGenerator;

--- a/src/Commands/API/TestsGeneratorCommand.php
+++ b/src/Commands/API/TestsGeneratorCommand.php
@@ -2,7 +2,7 @@
 
 namespace InfyOm\Generator\Commands\API;
 
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use InfyOm\Generator\Commands\BaseCommand;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\API\ApiTestGenerator;

--- a/src/Commands/APIScaffoldGeneratorCommand.php
+++ b/src/Commands/APIScaffoldGeneratorCommand.php
@@ -2,7 +2,7 @@
 
 namespace InfyOm\Generator\Commands;
 
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use InfyOm\Generator\Commands\Scaffold\ScaffoldBaseCommand;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\API\APIControllerGenerator;

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -3,7 +3,7 @@
 namespace InfyOm\Generator\Commands;
 
 use Illuminate\Console\Command;
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Utils\FileUtil;
 use Symfony\Component\Console\Input\InputArgument;

--- a/src/Commands/Common/MigrationGeneratorCommand.php
+++ b/src/Commands/Common/MigrationGeneratorCommand.php
@@ -2,7 +2,7 @@
 
 namespace InfyOm\Generator\Commands\Common;
 
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use InfyOm\Generator\Commands\BaseCommand;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\MigrationGenerator;

--- a/src/Commands/Common/ModelGeneratorCommand.php
+++ b/src/Commands/Common/ModelGeneratorCommand.php
@@ -2,7 +2,7 @@
 
 namespace InfyOm\Generator\Commands\Common;
 
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use InfyOm\Generator\Commands\BaseCommand;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\ModelGenerator;

--- a/src/Commands/Common/RepositoryGeneratorCommand.php
+++ b/src/Commands/Common/RepositoryGeneratorCommand.php
@@ -2,7 +2,7 @@
 
 namespace InfyOm\Generator\Commands\Common;
 
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use InfyOm\Generator\Commands\BaseCommand;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\RepositoryGenerator;

--- a/src/Commands/Scaffold/ControllerGeneratorCommand.php
+++ b/src/Commands/Scaffold/ControllerGeneratorCommand.php
@@ -2,7 +2,7 @@
 
 namespace InfyOm\Generator\Commands\Scaffold;
 
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\Scaffold\ControllerGenerator;
 

--- a/src/Commands/Scaffold/RequestsGeneratorCommand.php
+++ b/src/Commands/Scaffold/RequestsGeneratorCommand.php
@@ -2,7 +2,7 @@
 
 namespace InfyOm\Generator\Commands\Scaffold;
 
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\Scaffold\RequestGenerator;
 

--- a/src/Commands/Scaffold/ScaffoldGeneratorCommand.php
+++ b/src/Commands/Scaffold/ScaffoldGeneratorCommand.php
@@ -2,7 +2,7 @@
 
 namespace InfyOm\Generator\Commands\Scaffold;
 
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\MigrationGenerator;
 use InfyOm\Generator\Generators\ModelGenerator;

--- a/src/Commands/Scaffold/ViewsGeneratorCommand.php
+++ b/src/Commands/Scaffold/ViewsGeneratorCommand.php
@@ -2,7 +2,7 @@
 
 namespace InfyOm\Generator\Commands\Scaffold;
 
-use Illuminate\Foundation\Composer;
+use Illuminate\Support\Composer;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\Scaffold\ViewGenerator;
 


### PR DESCRIPTION
…to support Laravel 5.2

As The Illuminate\Foundation\Composer class has been moved to
Illuminate\Support\Composer in Laravel 5.2.