### PR TITLE
Pull primary key from DB schema if not provided via CLI option

### DIFF
--- a/src/Common/CommandData.php
+++ b/src/Common/CommandData.php
@@ -285,5 +285,6 @@ class CommandData
         $tableName = $this->dynamicVars['$TABLE_NAME$'];
 
         $this->inputFields = TableFieldsGenerator::generateFieldsFromTable($tableName);
+        $this->checkForDiffPrimaryKey();
     }
 }


### PR DESCRIPTION
If a user does not pass the primary CLI option and supplies fromTable/tableName, set the primary option by querying database schema 