### PR TITLE
Fix infyom.publish:templates

### DIFF
--- a/src/Commands/Publish/PublishTemplateCommand.php
+++ b/src/Commands/Publish/PublishTemplateCommand.php
@@ -42,7 +42,7 @@ class PublishTemplateCommand extends PublishBaseCommand
      */
     public function publishGeneratorTemplates()
     {
-        $templatesPath = __DIR__.'/../../templates';
+        $templatesPath = __DIR__.'/../../../templates';
 
         return $this->publishDirectory($templatesPath, $this->templatesDir, 'infyom-generator-templates');
     }


### PR DESCRIPTION
It looks like, when fixing issue #98, the PublishTemplateCommand was relocated, but the committer missed the use of `__DIR__` in the file, and didn't update the path to account for the additional directory depth, so `php artisan infyom.publish:templates` was only creating empty directories instead of actually publishing anything.  This commit fixes that.