### PR TITLE
Update migration.stub

### DIFF
--- a/templates/migration.stub
+++ b/templates/migration.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class Create$TABLE_NAME$Table extends Migration
+class Create$MODEL_NAME_PLURAL$Table extends Migration
 {
 
     /**


### PR DESCRIPTION
Fixed error with proper naming convention of the migration class name.