### PR TITLE
Required fields need double quotes.

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -184,7 +184,7 @@ class ModelGenerator extends BaseGenerator
 
         $template = TemplateUtil::fillTemplate($this->commandData->dynamicVars, $template);
 
-        $template = str_replace('$REQUIRED_FIELDS$', implode(', ', $this->generateRequiredFields()), $template);
+        $template = str_replace('$REQUIRED_FIELDS$', '"'.implode('", "', $this->generateRequiredFields()).'"', $template);
 
         $propertyTemplate = TemplateUtil::getTemplate('model.property', 'swagger-generator');
 

--- a/src/Generators/SwaggerGenerator.php
+++ b/src/Generators/SwaggerGenerator.php
@@ -100,7 +100,7 @@ class SwaggerGenerator
 
         $templateData = TemplateUtil::fillTemplate($variables, $template);
 
-        $templateData = str_replace('$REQUIRED_FIELDS$', implode(', ', $fillables), $templateData);
+        $templateData = str_replace('$REQUIRED_FIELDS$', '"'.implode('", "', $fillables).'"', $templateData);
 
         $propertyTemplate = TemplateUtil::getTemplate('model.property', 'swagger-generator');
 


### PR DESCRIPTION
Model required fields must be surrounded by double quotes in swagger annotations.