### PR TITLE
Change AppBaseController import code in controller.stub

### DIFF
--- a/templates/api/controller/api_controller.stub
+++ b/templates/api/controller/api_controller.stub
@@ -7,7 +7,7 @@ use $NAMESPACE_API_REQUEST$\Update$MODEL_NAME$APIRequest;
 use $NAMESPACE_MODEL$\$MODEL_NAME$;
 use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
 use Illuminate\Http\Request;
-use $NAMESPACE_CONTROLLER$\AppBaseController as InfyOmBaseController;
+use $NAMESPACE_APP$Http\Controllers\AppBaseController as InfyOmBaseController;
 use InfyOm\Generator\Criteria\LimitOffsetCriteria;
 use InfyOm\Generator\Utils\ResponseUtil;
 use Prettus\Repository\Criteria\RequestCriteria;

--- a/templates/scaffold/controller/controller.stub
+++ b/templates/scaffold/controller/controller.stub
@@ -6,7 +6,7 @@ use $NAMESPACE_REQUEST$;
 use $NAMESPACE_REQUEST$\Create$MODEL_NAME$Request;
 use $NAMESPACE_REQUEST$\Update$MODEL_NAME$Request;
 use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
-use $NAMESPACE_CONTROLLER$\AppBaseController as InfyOmBaseController;
+use $NAMESPACE_APP$Http\Controllers\AppBaseController as InfyOmBaseController;
 use Illuminate\Http\Request;
 use Flash;
 use Prettus\Repository\Criteria\RequestCriteria;


### PR DESCRIPTION
Hi,

When create controller with `--prefix` option, `$NAMESPACE_CONTROLLER$` sets with prefix. But AppBaseController is on App\Http\Controllers folder.

```bash
$ php artisan infyom:api_scaffold Role --prefix=admin
```

So use `$NAMESPACE_APP$Http\Controllers` instead `$NAMESPACE_CONTROLLER$`