### PR TITLE
fix datatable_controller AppBaseController namespace

### DIFF
--- a/templates/scaffold/controller/datatable_controller.stub
+++ b/templates/scaffold/controller/datatable_controller.stub
@@ -8,7 +8,7 @@ use $NAMESPACE_REQUEST$\Create$MODEL_NAME$Request;
 use $NAMESPACE_REQUEST$\Update$MODEL_NAME$Request;
 use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
 use Flash;
-use InfyOm\Generator\Controller\AppBaseController;
+use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
 use Response;
 
 class $MODEL_NAME$Controller extends AppBaseController


### PR DESCRIPTION
I fixed the bug where datatable_controller used the AppBaseController class from the vendor package instead from the published class.

cheers for the great package