### PR TITLE
fix generate int fields from table

### DIFF
--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -156,10 +156,12 @@ class TableFieldsGenerator
 
         if ($column->getAutoincrement()) {
             $fieldInput .= ',true';
-        }
-
-        if ($column->getUnsigned()) {
-            $fieldInput .= ',true';
+            
+            if ($column->getUnsigned()) {
+            	$fieldInput .= ',true';
+        	}        
+        } elseif ($column->getUnsigned()) {
+            $fieldInput .= ',false, true';
         }
 
         return $fieldInput;


### PR DESCRIPTION
Hi, this request is to fix a an issue I have detected in geneation of integer fields in the schema files.

The schema field that was generated for unsigned integers was `integer_field:integer,true`
which did not match the protoype.
  `integer( string $column, bool $autoIncrement = false, bool $unsigned = false)`

The modifications I made ensure the arguments are passed correctly in the Blueprint::integer.
