### PR TITLE
Fix for getting primary key when generating from table

### DIFF
--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -121,7 +121,7 @@ class TableFieldsGenerator
         $schema = DB::getDoctrineSchemaManager();
         $indexes = collect($schema->listTableIndexes($tableName));
 
-        $primaryKey = $indexes->first(function ($i, $index) {
+        $primaryKey = $indexes->first(function ($index) {
             return $index->isPrimary() && 1 === count($index->getColumns());
         });
 


### PR DESCRIPTION
When generating from a table you get an error: 

`[Symfony\Component\Debug\Exception\FatalThrowableError] 
Call to a member function isPrimary() on string`