### PR TITLE
labels are not generated for Select: fixed

### DIFF
--- a/src/Utils/GeneratorFieldsInputUtil.php
+++ b/src/Utils/GeneratorFieldsInputUtil.php
@@ -61,8 +61,8 @@ class GeneratorFieldsInputUtil
     public static function prepareKeyValueArrayStr($arr)
     {
         $arrStr = '[';
-        foreach ($arr as $item) {
-            $arrStr .= "'$item' => '$item', ";
+        foreach ($arr as $key=>$item) {
+            $arrStr .= "'$item' => '$key', ";
         }
 
         $arrStr = substr($arrStr, 0, strlen($arrStr) - 2);


### PR DESCRIPTION
Hi,

as I mentioned in [this issue](https://github.com/InfyOmLabs/laravel-generator/issues/283) labels for `select` and `radio`s are not generated. 
Please also update in 5.2