### PR TITLE
primary option used in views

### DIFF
--- a/src/Common/GeneratorConfig.php
+++ b/src/Common/GeneratorConfig.php
@@ -76,6 +76,9 @@ class GeneratorConfig
 
     public $tableName;
 
+    /** @var string */
+    protected $primaryName;
+
     /* Generator AddOns */
     public $addOns;
 
@@ -93,6 +96,7 @@ class GeneratorConfig
         $this->preparePrefixes();
         $this->loadPaths();
         $this->prepareTableName();
+        $this->preparePrimaryName();
         $this->loadNamespaces($commandData);
         $commandData = $this->loadDynamicVariables($commandData);
     }
@@ -203,6 +207,7 @@ class GeneratorConfig
         $commandData->addDynamicVariable('$NAMESPACE_REQUEST_BASE$', $this->nsRequestBase);
 
         $commandData->addDynamicVariable('$TABLE_NAME$', $this->tableName);
+        $commandData->addDynamicVariable('$PRIMARY_KEY_NAME$', $this->primaryName);
 
         $commandData->addDynamicVariable('$MODEL_NAME$', $this->mName);
         $commandData->addDynamicVariable('$MODEL_NAME_CAMEL$', $this->mCamel);
@@ -260,6 +265,15 @@ class GeneratorConfig
             $this->tableName = $this->getOption('tableName');
         } else {
             $this->tableName = $this->mSnakePlural;
+        }
+    }
+
+    public function preparePrimaryName()
+    {
+        if ($this->getOption('primary')) {
+            $this->primaryName = $this->getOption('primary');
+        } else {
+            $this->primaryName = 'id';
         }
     }
 

--- a/templates/api/test/api_test.stub
+++ b/templates/api/test/api_test.stub
@@ -24,7 +24,7 @@ class $MODEL_NAME$ApiTest extends TestCase
     public function testRead$MODEL_NAME$()
     {
         $$MODEL_NAME_CAMEL$ = $this->make$MODEL_NAME$();
-        $this->json('GET', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->id);
+        $this->json('GET', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
 
         $this->assertApiResponse($$MODEL_NAME_CAMEL$->toArray());
     }
@@ -37,7 +37,7 @@ class $MODEL_NAME$ApiTest extends TestCase
         $$MODEL_NAME_CAMEL$ = $this->make$MODEL_NAME$();
         $edited$MODEL_NAME$ = $this->fake$MODEL_NAME$Data();
 
-        $this->json('PUT', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->id, $edited$MODEL_NAME$);
+        $this->json('PUT', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$, $edited$MODEL_NAME$);
 
         $this->assertApiResponse($edited$MODEL_NAME$);
     }
@@ -48,10 +48,10 @@ class $MODEL_NAME$ApiTest extends TestCase
     public function testDelete$MODEL_NAME$()
     {
         $$MODEL_NAME_CAMEL$ = $this->make$MODEL_NAME$();
-        $this->json('DELETE', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->id);
+        $this->json('DELETE', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->i$PRIMARY_KEY_NAME$d);
 
         $this->assertApiSuccess();
-        $this->json('GET', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->id);
+        $this->json('GET', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
 
         $this->assertResponseStatus(404);
     }

--- a/templates/test/repository_test.stub
+++ b/templates/test/repository_test.stub
@@ -39,7 +39,7 @@ class $MODEL_NAME$RepositoryTest extends TestCase
     public function testRead$MODEL_NAME$()
     {
         $$MODEL_NAME_CAMEL$ = $this->make$MODEL_NAME$();
-        $db$MODEL_NAME$ = $this->$MODEL_NAME_CAMEL$Repo->find($$MODEL_NAME_CAMEL$->id);
+        $db$MODEL_NAME$ = $this->$MODEL_NAME_CAMEL$Repo->find($$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
         $db$MODEL_NAME$ = $db$MODEL_NAME$->toArray();
         $this->assertModelData($$MODEL_NAME_CAMEL$->toArray(), $db$MODEL_NAME$);
     }
@@ -51,9 +51,9 @@ class $MODEL_NAME$RepositoryTest extends TestCase
     {
         $$MODEL_NAME_CAMEL$ = $this->make$MODEL_NAME$();
         $fake$MODEL_NAME$ = $this->fake$MODEL_NAME$Data();
-        $updated$MODEL_NAME$ = $this->$MODEL_NAME_CAMEL$Repo->update($fake$MODEL_NAME$, $$MODEL_NAME_CAMEL$->id);
+        $updated$MODEL_NAME$ = $this->$MODEL_NAME_CAMEL$Repo->update($fake$MODEL_NAME$, $$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
         $this->assertModelData($fake$MODEL_NAME$, $updated$MODEL_NAME$->toArray());
-        $db$MODEL_NAME$ = $this->$MODEL_NAME_CAMEL$Repo->find($$MODEL_NAME_CAMEL$->id);
+        $db$MODEL_NAME$ = $this->$MODEL_NAME_CAMEL$Repo->find($$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
         $this->assertModelData($fake$MODEL_NAME$, $db$MODEL_NAME$->toArray());
     }
 
@@ -63,8 +63,8 @@ class $MODEL_NAME$RepositoryTest extends TestCase
     public function testDelete$MODEL_NAME$()
     {
         $$MODEL_NAME_CAMEL$ = $this->make$MODEL_NAME$();
-        $resp = $this->$MODEL_NAME_CAMEL$Repo->delete($$MODEL_NAME_CAMEL$->id);
+        $resp = $this->$MODEL_NAME_CAMEL$Repo->delete($$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
         $this->assertTrue($resp);
-        $this->assertNull($MODEL_NAME$::find($$MODEL_NAME_CAMEL$->id), '$MODEL_NAME$ should not exist in DB');
+        $this->assertNull($MODEL_NAME$::find($$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$), '$MODEL_NAME$ should not exist in DB');
     }
 }

--- a/templates/vuejs/test/api_test.stub
+++ b/templates/vuejs/test/api_test.stub
@@ -24,7 +24,7 @@ class $MODEL_NAME$ApiTest extends TestCase
     public function testRead$MODEL_NAME$()
     {
         $$MODEL_NAME_CAMEL$ = $this->make$MODEL_NAME$();
-        $this->json('GET', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->id);
+        $this->json('GET', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
 
         $this->assertApiResponse($$MODEL_NAME_CAMEL$->toArray());
     }
@@ -37,7 +37,7 @@ class $MODEL_NAME$ApiTest extends TestCase
         $$MODEL_NAME_CAMEL$ = $this->make$MODEL_NAME$();
         $edited$MODEL_NAME$ = $this->fake$MODEL_NAME$Data();
 
-        $this->json('PUT', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->id, $edited$MODEL_NAME$);
+        $this->json('PUT', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$, $edited$MODEL_NAME$);
 
         $this->assertApiResponse($edited$MODEL_NAME$);
     }
@@ -48,10 +48,10 @@ class $MODEL_NAME$ApiTest extends TestCase
     public function testDelete$MODEL_NAME$()
     {
         $$MODEL_NAME_CAMEL$ = $this->make$MODEL_NAME$();
-        $this->json('DELETE', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->id);
+        $this->json('DELETE', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
 
         $this->assertApiSuccess();
-        $this->json('GET', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->id);
+        $this->json('GET', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
 
         $this->assertResponseStatus(404);
     }


### PR DESCRIPTION
I noticed that specifying a custom primary key name using `--primary` doesn't have an effect on the view scripts, they still use `->id` to access the ID. This results in the action buttons linking to the edit/delete routes without an ID, what again results in a `NotFoundHttpException`.

This adds the primary option (or `id` if not set) as a dynamic variable `$PRIMARY_KEY_NAME$`. I will add PRs to use this variable in *adminlte-templates* and *core-templates*.