### PR TITLE
bug fix when using fromTable option

### DIFF
--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -86,7 +86,7 @@ class TableFieldsGenerator
                     break;
                 case 'boolean':
                     $name = title_case(str_replace('_', ' ', $column->getName()));
-                    $field = $this->generateField($column, 'bigInteger', 'checkbox,'.$name.',1');
+                    $field = $this->generateField($column, 'bigInteger', 'checkbox,1');
                     break;
                 case 'datetime':
                     $field = $this->generateField($column, 'datetime', 'date');
@@ -227,7 +227,7 @@ class TableFieldsGenerator
         $field = new GeneratorField();
         $field->name = $column->getName();
         $field->parseDBType($dbType);
-        $field->htmlType = $htmlType;
+        $field->parseHtmlInput($htmlType);
 
         return $this->checkForPrimary($field);
     }

--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -86,7 +86,7 @@ class TableFieldsGenerator
                     break;
                 case 'boolean':
                     $name = title_case(str_replace('_', ' ', $column->getName()));
-                    $field = $this->generateField($column, 'bigInteger', 'checkbox,1');
+                    $field = $this->generateField($column, 'boolean', 'checkbox,1');
                     break;
                 case 'datetime':
                     $field = $this->generateField($column, 'datetime', 'date');


### PR DESCRIPTION
1. not add checkbox in fields.blade.php when htmlType is boolean

`$fieldTemplate` is empty.
https://github.com/InfyOmLabs/laravel-generator/blob/5.2/src/Generators/Scaffold/ViewGenerator.php#L302

Because, `$field->htmlType` is not `checkbox`.
Example, `$field->htmlType` is `boolean,hoge,1`, 

2. not cast tinyint to boolean

tinyint cast to boolean when `$field->fieldType` is `boolean`.
https://github.com/InfyOmLabs/laravel-generator/blob/5.2/src/Generators/ModelGenerator.php#L230

But, `$field->fieldType` is `bigInteger`.
https://github.com/InfyOmLabs/laravel-generator/blob/5.2/src/Utils/TableFieldsGenerator.php#L89