### PR TITLE
Use copy of inputs array before applying array_shift

### DIFF
--- a/src/Common/GeneratorFieldRelation.php
+++ b/src/Common/GeneratorFieldRelation.php
@@ -64,7 +64,8 @@ class GeneratorFieldRelation
 
     private function generateRelation($functionName, $relation, $relationClass)
     {
-        $modelName = array_shift($this->inputs);
+        $inputs = $this->inputs;
+        $modelName = array_shift($inputs);
 
         $template = get_template('model.relationship', 'laravel-generator');
 
@@ -73,8 +74,8 @@ class GeneratorFieldRelation
         $template = str_replace('$RELATION$', $relation, $template);
         $template = str_replace('$RELATION_MODEL_NAME$', $modelName, $template);
 
-        if (count($this->inputs) > 0) {
-            $inputFields = implode("', '", $this->inputs);
+        if (count($inputs) > 0) {
+            $inputFields = implode("', '", $inputs);
             $inputFields = ", '".$inputFields."'";
         } else {
             $inputFields = '';


### PR DESCRIPTION
At present, there is a side effect when `Common\GeneratorFieldRelation::generateRelation` is run, removing the first element of the relation inputs, such that outputs are different on the second call (for instance, when generating JSON output after model output). This copies the input array to avoid `array_shift` removing the element permanently.