### PR TITLE
Made APIs versioned. Allowed working with the latest builder UI.

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -3,6 +3,8 @@
 namespace InfyOm\Generator\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Log;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\API\APIControllerGenerator;
 use InfyOm\Generator\Generators\API\APIRequestGenerator;
@@ -135,12 +137,12 @@ class BaseCommand extends Command
             $this->saveSchemaFile();
         }
 
-        if ($runMigration) {
-            if ($this->commandData->config->forceMigrate) {
-                $this->call('migrate');
+        if ($runMigration or $this->commandData->config->forceMigrate) {
+            if( $this->commandData->config->forceMigrate ){
+                Artisan::call('migrate');
             } elseif (!$this->commandData->getOption('fromTable') and !$this->isSkip('migration')) {
                 if ($this->confirm("\nDo you want to migrate database? [y|N]", false)) {
-                    $this->call('migrate');
+	            Artisan::call('migrate');
                 }
             }
         }
@@ -152,8 +154,9 @@ class BaseCommand extends Command
 
     public function isSkip($skip)
     {
-        if ($this->commandData->getOption('skip')) {
-            return in_array($skip, (array) $this->commandData->getOption('skip'));
+        $skip_data = $this->commandData->getOption('skip');
+        if ( $skip_data ) {
+            return in_array($skip, (array) $skip_data);
         }
 
         return false;

--- a/src/Common/GeneratorConfig.php
+++ b/src/Common/GeneratorConfig.php
@@ -76,6 +76,13 @@ class GeneratorConfig
         'relations',
     ];
 
+    public static $availableAddOns = [
+	'swagger',
+	'tests',
+	'datatables',
+	'menu.enabled',
+    ];
+
     public $tableName;
 
     /** @var string */
@@ -415,7 +422,7 @@ class GeneratorConfig
             }
         }
 
-        $addOns = ['swagger', 'tests', 'datatables'];
+        $addOns = self::$availableAddOns;
 
         foreach ($addOns as $addOn) {
             if (isset($jsonData['addOns'][$addOn])) {

--- a/templates/api/routes/routes.stub
+++ b/templates/api/routes/routes.stub
@@ -1,1 +1,1 @@
-Route::resource('$MODEL_NAME_PLURAL_SNAKE$', '$PATH_PREFIX$$MODEL_NAME$APIController');
+Route::resource('$API_VERSION$/$MODEL_NAME_PLURAL_SNAKE$', '$PATH_PREFIX$$MODEL_NAME$APIController');

--- a/templates/scaffold/routes/routes.stub
+++ b/templates/scaffold/routes/routes.stub
@@ -1,1 +1,1 @@
-Route::resource('$MODEL_NAME_PLURAL_CAMEL$', '$PATH_PREFIX$$MODEL_NAME$Controller');
+Route::resource('$API_VERSION$/$MODEL_NAME_PLURAL_CAMEL$', '$PATH_PREFIX$$MODEL_NAME$Controller');


### PR DESCRIPTION
This goes in hand with some other differences between other repos listed here:

- [generator-builder](https://github.com/InfyOmLabs/generator-builder/compare/master...EntranceJew:master)
- [adminlte-generator](https://github.com/InfyOmLabs/adminlte-generator/compare/5.3...EntranceJew:5.3)

Basically, I wanted to bring back the builder UI since I was able to identify the basic problems preventing it from properly passing data around or even from having migrations not being run.

I also identified some issues with the API doc generation. I don't know the best way to do it, but manually invoking:
`./vendor/bin/swagger app/ --stdout > ./storage/docs/api-docs.json`
Would be all that's necessary to run order to have swagger generate updated doc files after migrations run.