### PR TITLE
Fix enum in TestTraitGenerator.php

### DIFF
--- a/src/Generators/TestTraitGenerator.php
+++ b/src/Generators/TestTraitGenerator.php
@@ -72,8 +72,8 @@ class TestTraitGenerator extends BaseGenerator
                     $fakerData = "date('Y-m-d H:i:s')";
                     break;
                 case 'enum':
-                    $fakerData = 'randomElement(' .
-                        GeneratorFieldsInputUtil::prepareValuesArrayStr($field->htmlValues) .
+                    $fakerData = 'randomElement('.
+                        GeneratorFieldsInputUtil::prepareValuesArrayStr($field->htmlValues).
                         ')';
                     break;
                 default:

--- a/src/Generators/TestTraitGenerator.php
+++ b/src/Generators/TestTraitGenerator.php
@@ -72,8 +72,9 @@ class TestTraitGenerator extends BaseGenerator
                     $fakerData = "date('Y-m-d H:i:s')";
                     break;
                 case 'enum':
-                    $fakerData = 'randomElement('.GeneratorFieldsInputUtil::prepareValuesArrayStr(explode(',',
-                            $field['htmlTypeInputs'])).')';
+                    $fakerData = 'randomElement(' .
+                        GeneratorFieldsInputUtil::prepareValuesArrayStr($field->htmlValues) .
+                        ')';
                     break;
                 default:
                     $fakerData = 'word';


### PR DESCRIPTION
For enum fields infyom:api_scaffold command is failed with the error

`[Symfony\Component\Debug\Exception\FatalThrowableError]                    
  Cannot use object of type InfyOm\Generator\Common\GeneratorField as array`

This change repair the access to field attribute