### PR TITLE
Fixed get_template_file_path bug when working with swagger-generator.

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -90,10 +90,14 @@ if (!function_exists('get_template_file_path')) {
                 'infyom.laravel_generator.path.templates_dir',
                 base_path('resources/infyom/infyom-generator-templates/')
             );
+        } else {
+            $templatesPath = config(
+                'infyom.'. $templateType .'.path.templates_dir',
+                base_path('resources/infyom/'. $templateType .'/')
+            );
         }
 
         $path = $templatesPath.$templateName.'.stub';
-
         if (file_exists($path)) {
             return $path;
         }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -85,11 +85,12 @@ if (!function_exists('get_template_file_path')) {
     function get_template_file_path($templateName, $templateType)
     {
         $templateName = str_replace('.', '/', $templateName);
-
-        $templatesPath = config(
-            'infyom.laravel_generator.path.templates_dir',
-            base_path('resources/infyom/infyom-generator-templates/')
-        );
+        if ($templateType == 'laravel-generator') {
+            $templatesPath = config(
+                'infyom.laravel_generator.path.templates_dir',
+                base_path('resources/infyom/infyom-generator-templates/')
+            );
+        }
 
         $path = $templatesPath.$templateName.'.stub';
 


### PR DESCRIPTION
When using laravel-generator with swagger-generator , get_template_file_path always return `laravel-generator` package's template not from swagger-generator. 

That will cause generated model not usable. 

Signed-off-by: Rack Lin <racklin@gmail.com>