### PR TITLE
Update value when saving on belongsTo attribute

### DIFF
--- a/src/Common/BaseRepository.php
+++ b/src/Common/BaseRepository.php
@@ -61,7 +61,7 @@ abstract class BaseRepository extends \Prettus\Repository\Eloquent\BaseRepositor
                         break;
                     case 'Illuminate\Database\Eloquent\Relations\BelongsTo':
                         $model_key = $model->$key()->getForeignKey();
-                        $new_value = array_get($attributes, $key, null);
+                        $new_value = array_get($attributes, "{$key}.id", null);
                         $new_value = $new_value == '' ? null : $new_value;
                         $model->$model_key = $new_value;
                         break;


### PR DESCRIPTION
Uses $attribute->id to save to model foreign key.

Example:
$book = [
  "author" => [
     "id" => 1
  ]
];

create this new book when create book attribute and add 1 to author_id of book object.