### PR TITLE
Fixed incorrect use statements in repository_test.stub

### DIFF
--- a/templates/test/repository_test.stub
+++ b/templates/test/repository_test.stub
@@ -1,7 +1,7 @@
 <?php
 
-use App\Models\$MODEL_NAME$;
-use App\Repositories\$MODEL_NAME$Repository;
+use $NAMESPACE_MODEL$\$MODEL_NAME$;
+use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 
 class $MODEL_NAME$RepositoryTest extends TestCase


### PR DESCRIPTION
Generated use statements was incorrect when using "--prefix" option. Hardcoded "App\Models" and "App\Repositories" namespaces are replaced with proper variables.