### PR TITLE
Fixes #464

### DIFF
--- a/src/Common/BaseRepository.php
+++ b/src/Common/BaseRepository.php
@@ -60,7 +60,7 @@ abstract class BaseRepository extends \Prettus\Repository\Eloquent\BaseRepositor
                         $model->$key()->sync(array_values($new_values));
                         break;
                     case 'Illuminate\Database\Eloquent\Relations\BelongsTo':
-                        $model_key = $model->$key()->getForeignKey();
+                        $model_key = $model->$key()->getQualifiedForeignKeyName();
                         $new_value = array_get($attributes, $key, null);
                         $new_value = $new_value == '' ? null : $new_value;
                         $model->$model_key = $new_value;
@@ -75,7 +75,7 @@ abstract class BaseRepository extends \Prettus\Repository\Eloquent\BaseRepositor
                             unset($new_values[array_search('', $new_values)]);
                         }
 
-                        list($temp, $model_key) = explode('.', $model->$key($key)->getForeignKey());
+                        list($temp, $model_key) = explode('.', $model->$key($key)->getQualifiedForeignKeyName());
 
                         foreach ($model->$key as $rel) {
                             if (!in_array($rel->id, $new_values)) {


### PR DESCRIPTION
Fixes #464 - The method getForeignKey() was renamed to getQualifiedForeignKeyName() in Laravel 5.4