### PR TITLE
Fix #476: Map BIT type to BOOLEAN

### DIFF
--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -58,6 +58,7 @@ class TableFieldsGenerator
         $platform = $this->schemaManager->getDatabasePlatform();
         $platform->registerDoctrineTypeMapping('enum', 'string');
         $platform->registerDoctrineTypeMapping('json', 'text');
+        $platform->registerDoctrineTypeMapping('bit', 'boolean');
 
         $this->columns = $this->schemaManager->listTableColumns($tableName);
 


### PR DESCRIPTION
Here's a quick fix for #476 which will cover most cases, although a BIT is a *bit* more than a boolean: https://dev.mysql.com/doc/refman/5.7/en/bit-type.html

An alternative would be to allow the end user to declare/override its own mapping from the configuration file. 