### PR TITLE
Localization/language/translation & Custom fields' label

### DIFF
--- a/config/laravel_generator.php
+++ b/config/laravel_generator.php
@@ -44,6 +44,8 @@ return [
         'templates_dir'     => base_path('resources/infyom/infyom-generator-templates/'),
 
         'modelJs'           => base_path('resources/assets/js/models/'),
+
+        'language'          => base_path('resources/lang/'),
     ],
 
     /*
@@ -69,6 +71,15 @@ return [
 
         'api_request'       => 'App\Http\Requests\API',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Locale
+    |--------------------------------------------------------------------------
+    |
+    */
+
+    'locale'         => 'en',
 
     /*
     |--------------------------------------------------------------------------
@@ -129,6 +140,8 @@ return [
         'view' => '',  // using backend will create return view('backend.?.index') type the backend views directory
 
         'public' => '',
+
+        'language' => '', // using backend will create return __('backend.?.string') type the backend language directory
     ],
 
     /*

--- a/samples/fields_sample.json
+++ b/samples/fields_sample.json
@@ -1,6 +1,7 @@
 [
     {
         "name": "id",
+        "label": "ID",
         "dbType": "increments",
         "htmlType": "",
         "validations": "",
@@ -12,6 +13,7 @@
     },
     {
         "name": "title",
+        "label": "Title",
         "dbType": "string",
         "htmlType": "text",
         "validations": "required",
@@ -19,12 +21,14 @@
     },
     {
         "name": "post_date",
+        "label": "Post Date",
         "dbType": "dateTime",
         "htmlType": "date",
         "searchable": true
     },
     {
         "name": "body",
+        "label": "Some Custom Label",
         "dbType": "text",
         "htmlType": "textarea"
     },
@@ -46,6 +50,7 @@
     },
     {
         "name": "email",
+        "Label": "E-mail",
         "dbType": "string",
         "htmlType": "email",
         "searchable": true

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -13,6 +13,7 @@ use InfyOm\Generator\Generators\ModelGenerator;
 use InfyOm\Generator\Generators\RepositoryGenerator;
 use InfyOm\Generator\Generators\RepositoryTestGenerator;
 use InfyOm\Generator\Generators\Scaffold\ControllerGenerator;
+use InfyOm\Generator\Generators\Scaffold\LanguageGenerator;
 use InfyOm\Generator\Generators\Scaffold\MenuGenerator;
 use InfyOm\Generator\Generators\Scaffold\RequestGenerator;
 use InfyOm\Generator\Generators\Scaffold\RoutesGenerator;
@@ -118,6 +119,11 @@ class BaseCommand extends Command
             $viewGenerator->generate();
         }
 
+        if (!$this->isSkip('language')) {
+            $languageGenerator = new LanguageGenerator($this->commandData);
+            $languageGenerator->generate();
+        }
+
         if (!$this->isSkip('routes') and !$this->isSkip('scaffold_routes')) {
             $routeGenerator = new RoutesGenerator($this->commandData);
             $routeGenerator->generate();
@@ -173,6 +179,7 @@ class BaseCommand extends Command
         foreach ($this->commandData->fields as $field) {
             $fileFields[] = [
                 'name'        => $field->name,
+                'label'       => $field->label,
                 'dbType'      => $field->dbInput,
                 'htmlType'    => $field->htmlInput,
                 'validations' => $field->validations,

--- a/src/Commands/RollbackGeneratorCommand.php
+++ b/src/Commands/RollbackGeneratorCommand.php
@@ -13,6 +13,7 @@ use InfyOm\Generator\Generators\ModelGenerator;
 use InfyOm\Generator\Generators\RepositoryGenerator;
 use InfyOm\Generator\Generators\RepositoryTestGenerator;
 use InfyOm\Generator\Generators\Scaffold\ControllerGenerator;
+use InfyOm\Generator\Generators\Scaffold\LanguageGenerator;
 use InfyOm\Generator\Generators\Scaffold\MenuGenerator;
 use InfyOm\Generator\Generators\Scaffold\RequestGenerator;
 use InfyOm\Generator\Generators\Scaffold\RoutesGenerator;
@@ -108,6 +109,9 @@ class RollbackGeneratorCommand extends Command
 
         $viewGenerator = new ViewGenerator($this->commandData);
         $viewGenerator->rollback();
+
+        $languageGenerator = new LanguageGenerator($this->commandData);
+        $languageGenerator->rollback();
 
         $routeGenerator = new RoutesGenerator($this->commandData);
         $routeGenerator->rollback();

--- a/src/Commands/Scaffold/LanguageGeneratorCommand.php
+++ b/src/Commands/Scaffold/LanguageGeneratorCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace InfyOm\Generator\Commands\Scaffold;
+
+use InfyOm\Generator\Commands\BaseCommand;
+use InfyOm\Generator\Common\CommandData;
+use InfyOm\Generator\Generators\Scaffold\LanguageGenerator;
+
+class LanguageGeneratorCommand extends BaseCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'infyom.scaffold:language';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create language command';
+
+    /**
+     * Create a new command instance.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->commandData = new CommandData($this, CommandData::$COMMAND_TYPE_SCAFFOLD);
+    }
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        parent::handle();
+
+        $languageGenerator = new LanguageGenerator($this->commandData);
+        $languageGenerator->generate();
+
+        $this->performPostActions();
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return array_merge(parent::getOptions(), []);
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return array_merge(parent::getArguments(), []);
+    }
+}

--- a/src/Commands/VueJs/VueJsGeneratorCommand.php
+++ b/src/Commands/VueJs/VueJsGeneratorCommand.php
@@ -10,6 +10,7 @@ use InfyOm\Generator\Generators\RepositoryGenerator;
 use InfyOm\Generator\Generators\Scaffold\MenuGenerator;
 use InfyOm\Generator\Generators\VueJs\APIRequestGenerator;
 use InfyOm\Generator\Generators\VueJs\ControllerGenerator;
+use InfyOm\Generator\Generators\VueJs\LanguageGenerator;
 use InfyOm\Generator\Generators\VueJs\ModelJsConfigGenerator;
 use InfyOm\Generator\Generators\VueJs\RoutesGenerator;
 use InfyOm\Generator\Generators\VueJs\ViewGenerator;
@@ -65,6 +66,9 @@ class VueJsGeneratorCommand extends BaseCommand
 
         $controllerGenerator = new ControllerGenerator($this->commandData);
         $controllerGenerator->generate();
+
+        $languageGenerator = new LanguageGenerator($this->commandData);
+        $languageGenerator->generate();
 
         $viewGenerator = new ViewGenerator($this->commandData);
         $viewGenerator->generate();

--- a/src/Common/CommandData.php
+++ b/src/Common/CommandData.php
@@ -128,7 +128,7 @@ class CommandData
         $this->addPrimaryKey();
 
         while (true) {
-            $fieldInputStr = $this->commandObj->ask('Field: (name db_type html_type options)', '');
+            $fieldInputStr = $this->commandObj->ask('Field: (name db_type label html_type options)', '');
 
             if (empty($fieldInputStr) || $fieldInputStr == false || $fieldInputStr == 'exit') {
                 break;

--- a/src/Common/GeneratorConfig.php
+++ b/src/Common/GeneratorConfig.php
@@ -36,7 +36,11 @@ class GeneratorConfig
     public $pathRequest;
     public $pathRoutes;
     public $pathViews;
+    public $pathLanguage;
     public $modelJsPath;
+
+    /* Language Locale variable */
+    public $locale;
 
     /* Model Names */
     public $mName;
@@ -150,6 +154,14 @@ class GeneratorConfig
             $viewPrefix .= '/';
         }
 
+        $languagePrefix = $this->prefixes['language'];
+
+        $this->locale = config('infyom.laravel_generator.locale', 'en');
+
+        if (!empty($languagePrefix)) {
+            $languagePrefix .= '/';
+        }
+
         $this->pathRepository = config(
             'infyom.laravel_generator.path.repository',
             app_path('Repositories/')
@@ -191,6 +203,11 @@ class GeneratorConfig
             'infyom.laravel_generator.path.views',
             base_path('resources/views/')
         ).$viewPrefix.$this->mSnakePlural.'/';
+
+        $this->pathLanguage = config('infyom.laravel_generator.path.language', base_path('resources/lang/'))
+            .$this->locale
+            .'/'
+            .$languagePrefix;
 
         $this->modelJsPath = config(
                 'infyom.laravel_generator.path.modelsJs',
@@ -248,6 +265,12 @@ class GeneratorConfig
             $commandData->addDynamicVariable('$VIEW_PREFIX$', str_replace('/', '.', $this->prefixes['view']).'.');
         } else {
             $commandData->addDynamicVariable('$VIEW_PREFIX$', '');
+        }
+
+        if (!empty($this->prefixes['language'])) {
+            $commandData->addDynamicVariable('$LANGUAGE_PREFIX$', str_replace('/', '.', $this->prefixes['language']).'/');
+        } else {
+            $commandData->addDynamicVariable('$LANGUAGE_PREFIX$', '');
         }
 
         if (!empty($this->prefixes['public'])) {
@@ -335,6 +358,7 @@ class GeneratorConfig
         $this->prefixes['path'] = explode('/', config('infyom.laravel_generator.prefixes.path', ''));
         $this->prefixes['view'] = explode('.', config('infyom.laravel_generator.prefixes.view', ''));
         $this->prefixes['public'] = explode('/', config('infyom.laravel_generator.prefixes.public', ''));
+        $this->prefixes['language'] = explode('/', config('infyom.laravel_generator.prefixes.language', ''));
 
         if ($this->getOption('prefix')) {
             $multiplePrefixes = explode(',', $this->getOption('prefix'));
@@ -343,12 +367,14 @@ class GeneratorConfig
             $this->prefixes['path'] = array_merge($this->prefixes['path'], $multiplePrefixes);
             $this->prefixes['view'] = array_merge($this->prefixes['view'], $multiplePrefixes);
             $this->prefixes['public'] = array_merge($this->prefixes['public'], $multiplePrefixes);
+            $this->prefixes['language'] = array_merge($this->prefixes['language'], $multiplePrefixes);
         }
 
         $this->prefixes['route'] = array_diff($this->prefixes['route'], ['']);
         $this->prefixes['path'] = array_diff($this->prefixes['path'], ['']);
         $this->prefixes['view'] = array_diff($this->prefixes['view'], ['']);
         $this->prefixes['public'] = array_diff($this->prefixes['public'], ['']);
+        $this->prefixes['language'] = array_diff($this->prefixes['language'], ['']);
 
         $routePrefix = '';
 
@@ -409,6 +435,18 @@ class GeneratorConfig
         }
 
         $this->prefixes['public'] = $publicPrefix;
+
+        $languagePrefix = '';
+
+        foreach ($this->prefixes['language'] as $singlePrefix) {
+            $languagePrefix .= Str::camel($singlePrefix).'/';
+        }
+
+        if (!empty($languagePrefix)) {
+            $languagePrefix = substr($languagePrefix, 0, strlen($languagePrefix) - 1);
+        }
+
+        $this->prefixes['language'] = $languagePrefix;
     }
 
     public function overrideOptionsFromJsonFile($jsonData)

--- a/src/Common/GeneratorField.php
+++ b/src/Common/GeneratorField.php
@@ -8,6 +8,7 @@ class GeneratorField
 {
     /** @var string */
     public $name;
+    public $label;
     public $dbInput;
     public $htmlInput;
     public $htmlType;
@@ -126,6 +127,7 @@ class GeneratorField
     {
         $field = new self();
         $field->name = $fieldInput['name'];
+        $field->label = isset($fieldInput['label']) ? $fieldInput['label'] : Str::title(str_replace('_', ' ', $fieldInput['name']));
         $field->parseDBType($fieldInput['dbType']);
         $field->parseHtmlInput(isset($fieldInput['htmlType']) ? $fieldInput['htmlType'] : '');
         $field->validations = isset($fieldInput['validations']) ? $fieldInput['validations'] : '';

--- a/src/Generators/Scaffold/LanguageGenerator.php
+++ b/src/Generators/Scaffold/LanguageGenerator.php
@@ -42,6 +42,8 @@ class LanguageGenerator extends BaseGenerator
 
     private function fill_template($templateData)
     {
+        $templateData = str_replace('$MODEL_NAME_HUMAN$', $this->commandData->dynamicVars['$MODEL_NAME_HUMAN$'], $templateData);
+
         $fields_name_label = '';
 
         foreach ($this->commandData->fields as $field) {

--- a/src/Generators/Scaffold/LanguageGenerator.php
+++ b/src/Generators/Scaffold/LanguageGenerator.php
@@ -42,7 +42,7 @@ class LanguageGenerator extends BaseGenerator
 
     private function fill_template($templateData)
     {
-        $templateData = str_replace('$MODEL_NAME_HUMAN$', $this->commandData->dynamicVars['$MODEL_NAME_HUMAN$'], $templateData);
+        $templateData = fill_template($this->commandData->dynamicVars, $templateData);
 
         $fields_name_label = '';
 

--- a/src/Generators/Scaffold/LanguageGenerator.php
+++ b/src/Generators/Scaffold/LanguageGenerator.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace InfyOm\Generator\Generators\Scaffold;
+
+use InfyOm\Generator\Common\CommandData;
+use InfyOm\Generator\Generators\BaseGenerator;
+use InfyOm\Generator\Utils\FileUtil;
+
+class LanguageGenerator extends BaseGenerator
+{
+    /** @var CommandData */
+    private $commandData;
+
+    /** @var string */
+    private $path;
+
+    /** @var string */
+    private $locale;
+
+    /** @var string */
+    private $languageFileName;
+
+    public function __construct(CommandData $commandData)
+    {
+        $this->commandData = $commandData;
+        $this->path = $commandData->config->pathLanguage;
+        $this->locale = $commandData->config->locale;
+        $this->languageFileName = $this->commandData->dynamicVars['$MODEL_NAME_PLURAL_CAMEL$'].'.php';
+    }
+
+    public function generate()
+    {
+        $templateData = get_template('lang.'.$this->locale.'.strings', 'laravel-generator');
+
+        $templateData = $this->fill_template($templateData);
+
+        FileUtil::createFile($this->path, $this->languageFileName, $templateData);
+
+        $this->commandData->commandComment("\nLanguage created: ");
+        $this->commandData->commandInfo($this->languageFileName);
+    }
+
+    private function fill_template($templateData)
+    {
+        $fields_name_label = '';
+
+        foreach ($this->commandData->fields as $field) {
+            $fields_name_label .= "'".$field->name."' => '".(isset($field->label) ? $field->label : $field->name)."',\n\t";
+        }
+
+        $templateData = str_replace('$FIELDS_NAME_LABEL$', $fields_name_label, $templateData);
+
+        return $templateData;
+    }
+
+    public function rollback()
+    {
+        if ($this->rollbackFile($this->path, $this->createFileName)) {
+            $this->commandData->commandComment('Create language files deleted: '.$this->languageFileName);
+        }
+    }
+}

--- a/src/Generators/Scaffold/LanguageGenerator.php
+++ b/src/Generators/Scaffold/LanguageGenerator.php
@@ -47,7 +47,7 @@ class LanguageGenerator extends BaseGenerator
         $fields_name_label = '';
 
         foreach ($this->commandData->fields as $field) {
-            $fields_name_label .= "'".$field->name."' => '".(isset($field->label) ? $field->label : $field->name)."',\n\t";
+            $fields_name_label .= "'field.".$field->name."' => '".(isset($field->label) ? $field->label : $field->name)."',\n\t";
         }
 
         $templateData = str_replace('$FIELDS_NAME_LABEL$', $fields_name_label, $templateData);

--- a/src/InfyOmGeneratorServiceProvider.php
+++ b/src/InfyOmGeneratorServiceProvider.php
@@ -17,6 +17,7 @@ use InfyOm\Generator\Commands\Publish\PublishTemplateCommand;
 use InfyOm\Generator\Commands\Publish\VueJsLayoutPublishCommand;
 use InfyOm\Generator\Commands\RollbackGeneratorCommand;
 use InfyOm\Generator\Commands\Scaffold\ControllerGeneratorCommand;
+use InfyOm\Generator\Commands\Scaffold\LanguageGeneratorCommand;
 use InfyOm\Generator\Commands\Scaffold\RequestsGeneratorCommand;
 use InfyOm\Generator\Commands\Scaffold\ScaffoldGeneratorCommand;
 use InfyOm\Generator\Commands\Scaffold\ViewsGeneratorCommand;
@@ -99,6 +100,10 @@ class InfyOmGeneratorServiceProvider extends ServiceProvider
 
         $this->app->singleton('infyom.scaffold.requests', function ($app) {
             return new RequestsGeneratorCommand();
+        });
+
+        $this->app->singleton('infyom.scaffold.language', function ($app) {
+            return new LanguageGeneratorCommand();
         });
 
         $this->app->singleton('infyom.scaffold.views', function ($app) {

--- a/src/Utils/GeneratorFieldsInputUtil.php
+++ b/src/Utils/GeneratorFieldsInputUtil.php
@@ -44,13 +44,14 @@ class GeneratorFieldsInputUtil
         $field = new GeneratorField();
         $field->name = $fieldInputsArr[0];
         $field->parseDBType($fieldInputsArr[1]);
-
-        if (count($fieldInputsArr) > 2) {
-            $field->parseHtmlInput($fieldInputsArr[2]);
-        }
+        $field->label = $fieldInputsArr[2];
 
         if (count($fieldInputsArr) > 3) {
-            $field->parseOptions($fieldInputsArr[3]);
+            $field->parseHtmlInput($fieldInputsArr[3]);
+        }
+
+        if (count($fieldInputsArr) > 4) {
+            $field->parseOptions($fieldInputsArr[4]);
         }
 
         $field->validations = $validations;

--- a/templates/lang/en/strings.stub
+++ b/templates/lang/en/strings.stub
@@ -1,0 +1,42 @@
+<?php
+
+return [
+    'action' =>         'Action',
+    'addnew' =>         'Add New',
+    'save' =>           'Save',
+    'cancel' =>         'Cancel',
+    'delete' =>         'Delete',
+    'back' =>           'Back',
+    'areyousure' =>     'Are you sure?',
+    'form' =>           'Form',
+
+    'store.success' =>  ':name saved successfully.',
+    'update.success' => ':name updated successfully.',
+    'destroy.success'=> ':name deleted successfully.',
+    'notfound' =>       ':name not found.',
+
+    'sEmptyTable'=>     'No data available in table',
+    'sInfo'=>           'Showing _START_ to _END_ of _TOTAL_ entries',
+    'sInfoEmpty'=>      'Showing 0 to 0 of 0 entries',
+    'sInfoFiltered'=>   '(filtered from _MAX_ total entries)',
+    'sInfoPostFix'=>    '',
+    'sInfoThousands'=>  ',',
+    'sLengthMenu'=>     'Show _MENU_ entries',
+    'sLoadingRecords'=> 'Loading...',
+    'sProcessing'=>     'Processing...',
+    'sZeroRecords'=>    'No matching records found',
+    'sSearch'=>         'Search:',
+    'sFirst'=>          'First',
+    'sLast'=>           'Last',
+    'sNext'=>           'Next',
+    'sPrevious'=>       'Previous',
+    'sSortAscending'=>  ': activate to sort column ascending',
+    'sSortDescending'=> ': activate to sort column descending',
+    'create' =>         'Create',
+    'export' =>         'Export',
+    'print' =>          'Print',
+    'reset' =>          'Reset',
+    'reload' =>         'Reload',
+    
+    $FIELDS_NAME_LABEL$
+];

--- a/templates/lang/en/strings.stub
+++ b/templates/lang/en/strings.stub
@@ -1,6 +1,8 @@
 <?php
 
 return [
+    'model.name' =>     '[0,1] $MODEL_NAME_HUMAN$|[2,*] $MODEL_NAME_PLURAL_HUMAN$',
+    
     'action' =>         'Action',
     'addnew' =>         'Add New',
     'save' =>           'Save',

--- a/templates/lang/pt-br/strings.stub
+++ b/templates/lang/pt-br/strings.stub
@@ -1,6 +1,8 @@
 <?php
 
 return [
+    'model.name' =>     '[0,1] $MODEL_NAME_HUMAN$|[2,*] $MODEL_NAME_PLURAL_HUMAN$',
+    
     'action' =>         'Ação',
     'addnew' =>         'Adicionar Novo',
     'save' =>           'Salvar',

--- a/templates/lang/pt-br/strings.stub
+++ b/templates/lang/pt-br/strings.stub
@@ -10,10 +10,10 @@ return [
     'areyousure' =>     'Você tem certeza?',
     'form' =>           'Formulário',
 
-    'store.success' =>  ':name salvo com sucesso.',
-    'update.success' => ':name atualizado com sucesso.',
-    'destroy.success'=> ':name deletado com sucesso.',
-    'notfound' =>       ':name não encontrado(a).',
+    'store.success' =>  '$MODEL_NAME_HUMAN$ salvo com sucesso.',
+    'update.success' => '$MODEL_NAME_HUMAN$ atualizado com sucesso.',
+    'destroy.success'=> '$MODEL_NAME_HUMAN$ deletado com sucesso.',
+    'notfound' =>       '$MODEL_NAME_HUMAN$ não encontrado(a).',
 
     'sEmptyTable' =>    'Nenhum registro encontrado',
     'sInfo' =>          'Mostrando de _START_ até _END_ de _TOTAL_ registros',

--- a/templates/lang/pt-br/strings.stub
+++ b/templates/lang/pt-br/strings.stub
@@ -1,0 +1,42 @@
+<?php
+
+return [
+    'action' =>         'Ação',
+    'addnew' =>         'Adicionar Novo',
+    'save' =>           'Salvar',
+    'cancel' =>         'Cancelar',
+    'delete' =>         'Deletar',
+    'back' =>           'Voltar',
+    'areyousure' =>     'Você tem certeza?',
+    'form' =>           'Formulário',
+
+    'store.success' =>  ':name salvo com sucesso.',
+    'update.success' => ':name atualizado com sucesso.',
+    'destroy.success'=> ':name deletado com sucesso.',
+    'notfound' =>       ':name não encontrado(a).',
+
+    'sEmptyTable' =>    'Nenhum registro encontrado',
+    'sInfo' =>          'Mostrando de _START_ até _END_ de _TOTAL_ registros',
+    'sInfoEmpty' =>     'Mostrando 0 até 0 de 0 registros',
+    'sInfoFiltered' =>  '(Filtrados de _MAX_ registros)',
+    'sInfoPostFix' =>   '',
+    'sInfoThousands' => '.',
+    'sLengthMenu' =>    '_MENU_ resultados por página',
+    'sLoadingRecords'=> 'Carregando...',
+    'sProcessing' =>    'Processando...',
+    'sZeroRecords' =>   'Nenhum registro encontrado',
+    'sSearch' =>        'Pesquisar',
+    'sFirst' =>         'Primeiro',
+    'sLast' =>          'Último',
+    'sNext' =>          'Próximo',
+    'sPrevious' =>      'Anterior',
+    'sSortAscending' => ': Ordenar colunas de forma ascendente',
+    'sSortDescending'=> ': Ordenar colunas de forma descendente',
+    'create' =>         'Criar',
+    'export' =>         'Exportar',
+    'print' =>          'Imprimir',
+    'reset' =>          'Reiniciar',
+    'reload' =>         'Recarregar',
+    
+    $FIELDS_NAME_LABEL$
+];

--- a/templates/scaffold/controller/controller.stub
+++ b/templates/scaffold/controller/controller.stub
@@ -59,7 +59,7 @@ class $MODEL_NAME$Controller extends AppBaseController
 
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->create($input);
 
-        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.store.success', ['name' => '$MODEL_NAME_HUMAN$']));
+        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.store.success'));
 
         return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
     }
@@ -76,7 +76,7 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound'));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
@@ -96,7 +96,7 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound'));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
@@ -117,14 +117,14 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound'));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
 
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->update($request->all(), $id);
 
-        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.update.success', ['name' => '$MODEL_NAME_HUMAN$']));
+        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.update.success'));
 
         return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
     }
@@ -141,14 +141,14 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound'));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
 
         $this->$MODEL_NAME_CAMEL$Repository->delete($id);
 
-        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.destroy.success', ['name' => '$MODEL_NAME_HUMAN$']));
+        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.destroy.success'));
 
         return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
     }

--- a/templates/scaffold/controller/controller.stub
+++ b/templates/scaffold/controller/controller.stub
@@ -59,7 +59,7 @@ class $MODEL_NAME$Controller extends AppBaseController
 
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->create($input);
 
-        Flash::success('$MODEL_NAME_HUMAN$ saved successfully.');
+        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.store.success', ['name' => '$MODEL_NAME_HUMAN$']));
 
         return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
     }
@@ -76,7 +76,7 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error('$MODEL_NAME_HUMAN$ not found');
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
@@ -96,7 +96,7 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error('$MODEL_NAME_HUMAN$ not found');
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
@@ -117,14 +117,14 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error('$MODEL_NAME_HUMAN$ not found');
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
 
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->update($request->all(), $id);
 
-        Flash::success('$MODEL_NAME_HUMAN$ updated successfully.');
+        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.update.success', ['name' => '$MODEL_NAME_HUMAN$']));
 
         return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
     }
@@ -141,14 +141,14 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error('$MODEL_NAME_HUMAN$ not found');
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
 
         $this->$MODEL_NAME_CAMEL$Repository->delete($id);
 
-        Flash::success('$MODEL_NAME_HUMAN$ deleted successfully.');
+        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.destroy.success', ['name' => '$MODEL_NAME_HUMAN$']));
 
         return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
     }

--- a/templates/scaffold/controller/datatable_controller.stub
+++ b/templates/scaffold/controller/datatable_controller.stub
@@ -55,7 +55,7 @@ class $MODEL_NAME$Controller extends AppBaseController
 
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->create($input);
 
-        Flash::success('$MODEL_NAME_HUMAN$ saved successfully.');
+        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.store.success', ['name' => '$MODEL_NAME_HUMAN$']));
 
         return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
     }
@@ -72,7 +72,7 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error('$MODEL_NAME_HUMAN$ not found');
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
@@ -92,7 +92,7 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error('$MODEL_NAME_HUMAN$ not found');
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
@@ -113,14 +113,14 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error('$MODEL_NAME_HUMAN$ not found');
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
 
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->update($request->all(), $id);
 
-        Flash::success('$MODEL_NAME_HUMAN$ updated successfully.');
+        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.update.success', ['name' => '$MODEL_NAME_HUMAN$']));
 
         return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
     }
@@ -137,14 +137,14 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error('$MODEL_NAME_HUMAN$ not found');
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
 
         $this->$MODEL_NAME_CAMEL$Repository->delete($id);
 
-        Flash::success('$MODEL_NAME_HUMAN$ deleted successfully.');
+        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.destroy.success', ['name' => '$MODEL_NAME_HUMAN$']));
 
         return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
     }

--- a/templates/scaffold/controller/datatable_controller.stub
+++ b/templates/scaffold/controller/datatable_controller.stub
@@ -55,7 +55,7 @@ class $MODEL_NAME$Controller extends AppBaseController
 
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->create($input);
 
-        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.store.success', ['name' => '$MODEL_NAME_HUMAN$']));
+        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.store.success'));
 
         return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
     }
@@ -72,7 +72,7 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound'));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
@@ -92,7 +92,7 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound'));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
@@ -113,14 +113,14 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound'));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
 
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->update($request->all(), $id);
 
-        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.update.success', ['name' => '$MODEL_NAME_HUMAN$']));
+        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.update.success'));
 
         return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
     }
@@ -137,14 +137,14 @@ class $MODEL_NAME$Controller extends AppBaseController
         $$MODEL_NAME_CAMEL$ = $this->$MODEL_NAME_CAMEL$Repository->findWithoutFail($id);
 
         if (empty($$MODEL_NAME_CAMEL$)) {
-            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound', ['name' => '$MODEL_NAME_HUMAN$']));
+            Flash::error(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.notfound'));
 
             return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
         }
 
         $this->$MODEL_NAME_CAMEL$Repository->delete($id);
 
-        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.destroy.success', ['name' => '$MODEL_NAME_HUMAN$']));
+        Flash::success(__('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.destroy.success'));
 
         return redirect(route('$ROUTE_NAMED_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.index'));
     }

--- a/templates/scaffold/datatable.stub
+++ b/templates/scaffold/datatable.stub
@@ -42,7 +42,7 @@ class $MODEL_NAME$DataTable extends DataTable
         return $this->builder()
             ->columns($this->getColumns())
             ->minifiedAjax()
-            ->addAction(['width' => '80px'])
+            ->addAction(['width' => '80px', 'title' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.action')])
             ->parameters([
                 'dom'     => 'Bfrtip',
                 'order'   => [[0, 'desc']],
@@ -53,6 +53,36 @@ class $MODEL_NAME$DataTable extends DataTable
                     'reset',
                     'reload',
                 ],
+                'language' => [
+                    'sEmptyTable' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sEmptyTable'),
+                    'sInfo' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sInfo'),
+                    'sInfoEmpty' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sInfoEmpty'),
+                    'sInfoFiltered' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sInfoFiltered'),
+                    'sInfoPostFix' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sInfoPostFix'),
+                    'sInfoThousands' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sInfoThousands'),
+                    'sLengthMenu' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sLengthMenu'),
+                    'sLoadingRecords' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sLoadingRecords'),
+                    'sProcessing' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sProcessing'),
+                    'sZeroRecords' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sZeroRecords'),
+                    'sSearch' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sSearch'),
+                    'oPaginate' => [
+                        'sNext' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sNext'),
+                        'sPrevious' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sPrevious'),
+                        'sFirst' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sFirst'),
+                        'sLast' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sLast'),
+                    ],
+                    'oAria' => [
+                        'sSortAscending' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sSortAscending'),
+                        'sSortDescending' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.sSortDescending'),
+                    ],
+                    'buttons' => [
+                        'create' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.create'),
+                        'export' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.export'),
+                        'print' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.print'),
+                        'reset' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.reset'),
+                        'reload' => __('$LANGUAGE_PREFIX$$MODEL_NAME_PLURAL_CAMEL$.reload'),
+                    ]
+                ]
             ]);
     }
 


### PR DESCRIPTION
# Introducing localization

Based on [Laravel Localization](https://laravel.com/docs/5.5/localization), user can scaffold a language file that will contain (almost) all the texts/strings displayed at the views, which can be translated. Even the datatables texts/strings was included in the language file.

For now, there are only two available languages: English (`templates/lang/en/strings.stub`) and Brazilian Portuguese (`templates/lang/pt-br/strings.stub`). Contributors can easily add a new translation, just by creating a subdirectory for the language in `templates/lang` (e.g. `templates/lang/es` for Spanish language) and a file named `strings.stub` inside that subdirectory, defining all the strings translations as in `templates/lang/en/strings.stub`.

## Configuration

The user can choose the language in `config/infyom/laravel_generator.php` configuration file through:

```
'locale'         => 'en'
```

The user can set the base path where the language files are stored:

```
'path' => [
    'language' => base_path('resources/lang/'),
],
```

Lastly, the user can set a prefix to generate the language file in a subdirectory through:

```
'prefixes' => [
    'language' => '', // using backend will create return __('backend.?.string') type the backend language directory
],
```

The language file's name itself will be the model's name in plural and lowercase.

The controllers' Flash messages and even the datatable texts/strings was included in the language file for easy translations or customizations.

## Example

So, if user sets the following configuration in `config/infyom/laravel_generator.php`:

```
'locale' => 'en',
'path' => [ 'language' => base_path('resources/lang/') ],
'prefixes' => [ 'language' => 'backend' ],
```

...and the model name is `User`, then the full path to the generated language file will looks like:

`resources/lang/en/backend/users.php`

# Introducing label to fields

With this update, the user can set a label to each field, that will be displayed at the views and set at the language file. It's optional: if the label is not set, then it will be like [before this update](https://github.com/InfyOmLabs/laravel-generator/blob/b0cd27100bc89fd155623a9a1994450259992878/src/Common/GeneratorField.php#L144), that is, the field's name with "_" replaced by " " and upper initial characters, or in terms of programing: `Str::title(str_replace('_', ' ', $this->name));`

The fields' label will be stored in the language file and will be displayed in views like `__('prefix.model.field_name')`.

## Configuration

The user can set the field's input from Console or from File, when specifying field inputs in the format:

`name db_type label html_type options`

## Example

Check out the updated [samples/fields_sample.json](https://github.com/InfyOmLabs/laravel-generator/pull/504/commits/6bfaa8f02986a5ef8d8ba5838975f069391dc194#diff-84202a38822a47892853fbefbd171113) for full example when generating fields from File.

Simple example:

```
[
    {
        "name": "id",
        "label": "ID",
        "dbType": "increments",
        "htmlType": "",
        "validations": "",
        "searchable": false,
        "fillable": false,
        "primary": true,
        "inForm": false,
        "inIndex": false
    },
    {
        "name": "title", 
        // No label specified for "title", so it will be "Title"
        "dbType": "string",
        "htmlType": "text",
        "validations": "required",
        "searchable": true
    },
    {
        "name": "body",
        "label": "Some Custom Label",
        "dbType": "text",
        "htmlType": "textarea"
    }
]
```

# Needed changes in [InfyOmLabs/adminlte-templates](https://github.com/InfyOmLabs/adminlte-templates)

As the views are provided by [InfyOmLabs/adminlte-templates](https://github.com/InfyOmLabs/adminlte-templates) by default, it was also changed to follow the current updates. Check those changes on: https://github.com/InfyOmLabs/adminlte-templates/pull/22