### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "~5.0",
+        "illuminate/support": "5.0.* || 5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
         "prettus/l5-repository": "~2.6",
         "laracasts/flash": "~3.0"
     },


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.