### PR TITLE
Fix Tests Generation For Laravel 5.5

### DIFF
--- a/config/laravel_generator.php
+++ b/config/laravel_generator.php
@@ -35,7 +35,7 @@ return [
 
         'repository_test'   => base_path('tests/repositories/'),
 
-        'api_test'          => base_path('tests/Feature/API/'),
+        'api_test'          => base_path('tests/'),
 
         'views'             => base_path('resources/views/'),
 

--- a/config/laravel_generator.php
+++ b/config/laravel_generator.php
@@ -33,9 +33,9 @@ return [
 
         'test_trait'        => base_path('tests/traits/'),
 
-        'repository_test'   => base_path('tests/'),
+        'repository_test'   => base_path('tests/repositories/'),
 
-        'api_test'          => base_path('tests/'),
+        'api_test'          => base_path('tests/Feature/API/'),
 
         'views'             => base_path('resources/views/'),
 

--- a/src/Generators/TestTraitGenerator.php
+++ b/src/Generators/TestTraitGenerator.php
@@ -68,7 +68,7 @@ class TestTraitGenerator extends BaseGenerator
                 case 'text':
                     $fakerData = 'text';
                     break;
-                case 'datetime':
+                case 'dateTime':
                     $fakerData = "date('Y-m-d H:i:s')";
                     break;
                 case 'enum':

--- a/src/Generators/TestTraitGenerator.php
+++ b/src/Generators/TestTraitGenerator.php
@@ -55,6 +55,10 @@ class TestTraitGenerator extends BaseGenerator
                 continue;
             }
 
+            if ($field->fieldType === 'timestamp') {
+                continue;
+            }
+
             $fieldData = "'".$field->name."' => ".'$fake->';
 
             switch ($field->fieldType) {
@@ -69,7 +73,6 @@ class TestTraitGenerator extends BaseGenerator
                     $fakerData = 'text';
                     break;
                 case 'dateTime':
-                case 'timestamp':
                     $fakerData = "date('Y-m-d H:i:s')";
                     break;
                 case 'enum':

--- a/src/Generators/TestTraitGenerator.php
+++ b/src/Generators/TestTraitGenerator.php
@@ -59,6 +59,10 @@ class TestTraitGenerator extends BaseGenerator
                 continue;
             }
 
+            if (!$field->isFillable) {
+                continue;
+            }
+
             $fieldData = "'".$field->name."' => ".'$fake->';
 
             switch ($field->fieldType) {

--- a/src/Generators/TestTraitGenerator.php
+++ b/src/Generators/TestTraitGenerator.php
@@ -69,6 +69,7 @@ class TestTraitGenerator extends BaseGenerator
                     $fakerData = 'text';
                     break;
                 case 'dateTime':
+                case 'timestamp':
                     $fakerData = "date('Y-m-d H:i:s')";
                     break;
                 case 'enum':

--- a/templates/api/test/api_test.stub
+++ b/templates/api/test/api_test.stub
@@ -1,8 +1,12 @@
 <?php
 
+namespace Tests\Feature\API;
+
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\ApiTestTrait;
 use Tests\TestCase;
+use Tests\Traits\Make$MODEL_NAME$Trait;
 
 class $MODEL_NAME$ApiTest extends TestCase
 {

--- a/templates/api/test/api_test.stub
+++ b/templates/api/test/api_test.stub
@@ -18,7 +18,7 @@ class $MODEL_NAME$ApiTest extends TestCase
     public function testCreate$MODEL_NAME$()
     {
         $$MODEL_NAME_CAMEL$ = $this->fake$MODEL_NAME$Data();
-        $this->response = $this->json('POST', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$', $$MODEL_NAME_CAMEL$);
+        $this->response = $this->json('POST', '/api/$MODEL_NAME_PLURAL_CAMEL$', $$MODEL_NAME_CAMEL$);
 
         $this->assertApiResponse($$MODEL_NAME_CAMEL$);
     }
@@ -29,7 +29,7 @@ class $MODEL_NAME$ApiTest extends TestCase
     public function testRead$MODEL_NAME$()
     {
         $$MODEL_NAME_CAMEL$ = $this->make$MODEL_NAME$();
-        $this->response = $this->json('GET', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
+        $this->response = $this->json('GET', '/api/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
 
         $this->assertApiResponse($$MODEL_NAME_CAMEL$->toArray());
     }
@@ -42,7 +42,7 @@ class $MODEL_NAME$ApiTest extends TestCase
         $$MODEL_NAME_CAMEL$ = $this->make$MODEL_NAME$();
         $edited$MODEL_NAME$ = $this->fake$MODEL_NAME$Data();
 
-        $this->response = $this->json('PUT', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$, $edited$MODEL_NAME$);
+        $this->response = $this->json('PUT', '/api/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$, $edited$MODEL_NAME$);
 
         $this->assertApiResponse($edited$MODEL_NAME$);
     }
@@ -53,10 +53,10 @@ class $MODEL_NAME$ApiTest extends TestCase
     public function testDelete$MODEL_NAME$()
     {
         $$MODEL_NAME_CAMEL$ = $this->make$MODEL_NAME$();
-        $this->response = $this->json('DELETE', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
+        $this->response = $this->json('DELETE', '/api/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
 
         $this->assertApiSuccess();
-        $this->response = $this->json('GET', '/api/v1/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
+        $this->response = $this->json('GET', '/api/$MODEL_NAME_PLURAL_CAMEL$/'.$$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
 
         $this->response->assertStatus(404);
     }

--- a/templates/api/test/api_test.stub
+++ b/templates/api/test/api_test.stub
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\Feature\API;
+namespace Tests;
 
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/templates/test/api_test_trait.stub
+++ b/templates/test/api_test_trait.stub
@@ -1,9 +1,11 @@
 <?php
 
+namespace Tests;
+
 trait ApiTestTrait
 {
     private $response;
-    public function assertApiResponse(Array $actualData)
+    public function assertApiResponse(array $actualData)
     {
         $this->assertApiSuccess();
 
@@ -20,7 +22,7 @@ trait ApiTestTrait
         $this->response->assertJson(['success' => true]);
     }
 
-    public function assertModelData(Array $actualData, Array $expectedData)
+    public function assertModelData(array $actualData, array $expectedData)
     {
         foreach ($actualData as $key => $value) {
             $this->assertEquals($actualData[$key], $expectedData[$key]);

--- a/templates/test/repository_test.stub
+++ b/templates/test/repository_test.stub
@@ -1,9 +1,13 @@
 <?php
 
+namespace Tests\Repositories;
+
 use $NAMESPACE_MODEL$\$MODEL_NAME$;
 use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\ApiTestTrait;
 use Tests\TestCase;
+use Tests\Traits\Make$MODEL_NAME$Trait;
 
 class $MODEL_NAME$RepositoryTest extends TestCase
 {

--- a/templates/test/trait.stub
+++ b/templates/test/trait.stub
@@ -1,8 +1,12 @@
 <?php
 
+namespace Tests\Traits;
+
+use Carbon\Carbon;
 use Faker\Factory as Faker;
 use $NAMESPACE_MODEL$\$MODEL_NAME$;
 use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
+use Illuminate\Support\Facades\App;
 
 trait Make$MODEL_NAME$Trait
 {


### PR DESCRIPTION
This includes the fixes from pull request #518 plus some other essential base structuring needed to make this generator work with Laravel 5.5.

These fixes will no longer require you to follow number four and five from [this](http://labs.infyom.com/laravelgenerator/docs/5.5/generator-options#test-cases) step from the documentation.