### PR TITLE
fix hardcoded PHPDoc comment

### DIFF
--- a/templates/scaffold/datatable.stub
+++ b/templates/scaffold/datatable.stub
@@ -24,7 +24,7 @@ class $MODEL_NAME$DataTable extends DataTable
     /**
      * Get query source of dataTable.
      *
-     * @param \App\Models\Post $model
+     * @param \App\Models\$MODEL_NAME$ $model
      * @return \Illuminate\Database\Eloquent\Builder
      */
     public function query($MODEL_NAME$ $model)


### PR DESCRIPTION
@param PHPDoc should dynamically point to $MODEL_NAME$