### PR TITLE
WIP: Make more configurable

### DIFF
--- a/config/laravel_generator.php
+++ b/config/laravel_generator.php
@@ -181,7 +181,35 @@ return [
     'ignore_model_prefix' => false,
 
     'classes' => [
+        'Common' => [
+            'command_data' => \InfyOm\Generator\Common\CommandData::class,
+            'generator_config' => \InfyOm\Generator\Common\GeneratorConfig::class,
+            'generator_field' => \InfyOm\Generator\Common\GeneratorField::class,
+            'generator_field_relation' => \InfyOm\Generator\Common\GeneratorFieldRelation::class,
+        ],
         'Generators' => [
+            'API' => [
+                'api_controller' => \InfyOm\Generator\Generators\API\APIControllerGenerator::class,
+                'api_request' => \InfyOm\Generator\Generators\API\APIRequestGenerator::class,
+                'api_routes' => \InfyOm\Generator\Generators\API\APIRoutesGenerator::class,
+                'api_test' => \InfyOm\Generator\Generators\API\APITestGenerator::class,
+            ],
+            'Scaffold' => [
+                'controller' =>  \InfyOm\Generator\Generators\Scaffold\ControllerGenerator::class,
+                'menu' =>  \InfyOm\Generator\Generators\Scaffold\MenuGenerator::class,
+                'request' =>  \InfyOm\Generator\Generators\Scaffold\RequestGenerator::class,
+                'routes' =>  \InfyOm\Generator\Generators\Scaffold\RoutesGenerator::class,
+                'view' =>  \InfyOm\Generator\Generators\Scaffold\ViewGenerator::class,
+            ],
+            'VueJs' => [
+                'api_request' => \InfyOm\Generator\Generators\VueJs\APIRequestGenerator::class,
+                'controller' => \InfyOm\Generator\Generators\VueJs\ControllerGenerator::class,
+                'model_js_config' => \InfyOm\Generator\Generators\VueJs\ModelJsConfigGenerator::class,
+                'routes' => \InfyOm\Generator\Generators\Vuejs\RoutesGenerator::class,
+                'test' => \InfyOm\Generator\Generators\API\TestGenerator::class,
+                'view' => \InfyOm\Generator\Generators\VueJs\ViewGenerator::class,
+
+            ],
             'migration' => \InfyOm\Generator\Generators\MigrationGenerator::class,
             'model' => \InfyOm\Generator\Generators\ModelGenerator::class,
             'repository' => \InfyOm\Generator\Generators\RepositoryGenerator::class,

--- a/config/laravel_generator.php
+++ b/config/laravel_generator.php
@@ -180,4 +180,14 @@ return [
     */
     'ignore_model_prefix' => false,
 
+    'classes' => [
+        'Generators' => [
+            'migration' => \InfyOm\Generator\Generators\MigrationGenerator::class,
+            'model' => \InfyOm\Generator\Generators\ModelGenerator::class,
+            'repository' => \InfyOm\Generator\Generators\RepositoryGenerator::class,
+            'repository_test' => \InfyOm\Generator\Generators\RepositoryTestGenerator::class,
+            'swagger' => \InfyOm\Generator\Generators\SwaggerGenerator::class,
+            'test_trait' => \InfyOm\Generator\Generators\TestTraitGenerator::class
+        ]
+    ]
 ];

--- a/config/laravel_generator.php
+++ b/config/laravel_generator.php
@@ -180,42 +180,13 @@ return [
     */
     'ignore_model_prefix' => false,
 
+    /**
+     * @see \InfyOm\Generator\Common\ClassInjectionConfig::$defaultClasses
+     *
+     * You may override InfyOm code generation classes with your own here.
+     * Please see ClassInjectionConfig::$defaultClasses for classes to override.
+     * Following the same array structure and providing classes which extend those which you want to replace will work best
+     */
     'classes' => [
-        'Common' => [
-            'command_data' => \InfyOm\Generator\Common\CommandData::class,
-            'generator_config' => \InfyOm\Generator\Common\GeneratorConfig::class,
-            'generator_field' => \InfyOm\Generator\Common\GeneratorField::class,
-            'generator_field_relation' => \InfyOm\Generator\Common\GeneratorFieldRelation::class,
-        ],
-        'Generators' => [
-            'API' => [
-                'api_controller' => \InfyOm\Generator\Generators\API\APIControllerGenerator::class,
-                'api_request' => \InfyOm\Generator\Generators\API\APIRequestGenerator::class,
-                'api_routes' => \InfyOm\Generator\Generators\API\APIRoutesGenerator::class,
-                'api_test' => \InfyOm\Generator\Generators\API\APITestGenerator::class,
-            ],
-            'Scaffold' => [
-                'controller' =>  \InfyOm\Generator\Generators\Scaffold\ControllerGenerator::class,
-                'menu' =>  \InfyOm\Generator\Generators\Scaffold\MenuGenerator::class,
-                'request' =>  \InfyOm\Generator\Generators\Scaffold\RequestGenerator::class,
-                'routes' =>  \InfyOm\Generator\Generators\Scaffold\RoutesGenerator::class,
-                'view' =>  \InfyOm\Generator\Generators\Scaffold\ViewGenerator::class,
-            ],
-            'VueJs' => [
-                'api_request' => \InfyOm\Generator\Generators\VueJs\APIRequestGenerator::class,
-                'controller' => \InfyOm\Generator\Generators\VueJs\ControllerGenerator::class,
-                'model_js_config' => \InfyOm\Generator\Generators\VueJs\ModelJsConfigGenerator::class,
-                'routes' => \InfyOm\Generator\Generators\Vuejs\RoutesGenerator::class,
-                'test' => \InfyOm\Generator\Generators\API\TestGenerator::class,
-                'view' => \InfyOm\Generator\Generators\VueJs\ViewGenerator::class,
-
-            ],
-            'migration' => \InfyOm\Generator\Generators\MigrationGenerator::class,
-            'model' => \InfyOm\Generator\Generators\ModelGenerator::class,
-            'repository' => \InfyOm\Generator\Generators\RepositoryGenerator::class,
-            'repository_test' => \InfyOm\Generator\Generators\RepositoryTestGenerator::class,
-            'swagger' => \InfyOm\Generator\Generators\SwaggerGenerator::class,
-            'test_trait' => \InfyOm\Generator\Generators\TestTraitGenerator::class
-        ]
     ]
 ];

--- a/src/Commands/API/APIControllerGeneratorCommand.php
+++ b/src/Commands/API/APIControllerGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Commands\API;
 
 use InfyOm\Generator\Commands\BaseCommand;
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\API\APIControllerGenerator;
 
@@ -29,13 +30,14 @@ class APIControllerGeneratorCommand extends BaseCommand
     {
         parent::__construct();
 
-        $this->commandData = new CommandData($this, CommandData::$COMMAND_TYPE_API);
+        $this->commandData = ClassInjectionConfig::createClassByConfigPath('Common.command_data', [$this, CommandData::$COMMAND_TYPE_API]);
     }
 
     /**
      * Execute the command.
      *
      * @return void
+     * @throws \ReflectionException
      */
     public function handle()
     {

--- a/src/Commands/API/APIControllerGeneratorCommand.php
+++ b/src/Commands/API/APIControllerGeneratorCommand.php
@@ -41,7 +41,8 @@ class APIControllerGeneratorCommand extends BaseCommand
     {
         parent::handle();
 
-        $controllerGenerator = new APIControllerGenerator($this->commandData);
+        /** @var APIControllerGenerator $controllerGenerator */
+        $controllerGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_controller', [$this->commandData]);
         $controllerGenerator->generate();
 
         $this->performPostActions();

--- a/src/Commands/API/APIGeneratorCommand.php
+++ b/src/Commands/API/APIGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Commands\API;
 
 use InfyOm\Generator\Commands\BaseCommand;
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 
 class APIGeneratorCommand extends BaseCommand
@@ -23,12 +24,13 @@ class APIGeneratorCommand extends BaseCommand
 
     /**
      * Create a new command instance.
+     * @throws \ReflectionException
      */
     public function __construct()
     {
         parent::__construct();
 
-        $this->commandData = new CommandData($this, CommandData::$COMMAND_TYPE_API);
+        $this->commandData = ClassInjectionConfig::createClassByConfigPath('Common.command_data', [$this, CommandData::$COMMAND_TYPE_API]);
     }
 
     /**

--- a/src/Commands/API/APIRequestsGeneratorCommand.php
+++ b/src/Commands/API/APIRequestsGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Commands\API;
 
 use InfyOm\Generator\Commands\BaseCommand;
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\API\APIRequestGenerator;
 
@@ -24,25 +25,27 @@ class APIRequestsGeneratorCommand extends BaseCommand
 
     /**
      * Create a new command instance.
+     * @throws \ReflectionException
      */
     public function __construct()
     {
         parent::__construct();
 
-        $this->commandData = new CommandData($this, CommandData::$COMMAND_TYPE_API);
+        $this->commandData = ClassInjectionConfig::createClassByConfigPath('Common.command_data', [$this, CommandData::$COMMAND_TYPE_API]);
     }
 
     /**
      * Execute the command.
      *
      * @return void
+     * @throws \ReflectionException
      */
     public function handle()
     {
         parent::handle();
 
-        /** @var APIRequestGenerator $requestGenerator */
-        $requestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_request', [$this->commandData]);
+        /** @var APIRequestGenerator $controllerGenerator */
+        $controllerGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_request', [$this->commandData]);
         $controllerGenerator->generate();
 
         $this->performPostActions();

--- a/src/Commands/API/APIRequestsGeneratorCommand.php
+++ b/src/Commands/API/APIRequestsGeneratorCommand.php
@@ -41,7 +41,8 @@ class APIRequestsGeneratorCommand extends BaseCommand
     {
         parent::handle();
 
-        $controllerGenerator = new APIRequestGenerator($this->commandData);
+        /** @var APIRequestGenerator $requestGenerator */
+        $requestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_request', [$this->commandData]);
         $controllerGenerator->generate();
 
         $this->performPostActions();

--- a/src/Commands/API/TestsGeneratorCommand.php
+++ b/src/Commands/API/TestsGeneratorCommand.php
@@ -53,7 +53,8 @@ class TestsGeneratorCommand extends BaseCommand
         $testTraitGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.test_trait', [$this->commandData]);
         $testTraitGenerator->generate();
 
-        $apiTestGenerator = new APITestGenerator($this->commandData);
+        /** @var APITestGenerator $apiTestGenerator */
+        $apiTestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_test', [$this->commandData]);
         $apiTestGenerator->generate();
 
         $this->performPostActions();

--- a/src/Commands/API/TestsGeneratorCommand.php
+++ b/src/Commands/API/TestsGeneratorCommand.php
@@ -32,7 +32,7 @@ class TestsGeneratorCommand extends BaseCommand
     {
         parent::__construct();
 
-        $this->commandData = new CommandData($this, CommandData::$COMMAND_TYPE_API);
+        $this->commandData = ClassInjectionConfig::createClassByConfigPath('Common.command_data', [$this, CommandData::$COMMAND_TYPE_API]);
     }
 
     /**

--- a/src/Commands/API/TestsGeneratorCommand.php
+++ b/src/Commands/API/TestsGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Commands\API;
 
 use InfyOm\Generator\Commands\BaseCommand;
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\API\APITestGenerator;
 use InfyOm\Generator\Generators\RepositoryTestGenerator;
@@ -38,15 +39,18 @@ class TestsGeneratorCommand extends BaseCommand
      * Execute the command.
      *
      * @return void
+     * @throws \ReflectionException
      */
     public function handle()
     {
         parent::handle();
 
-        $repositoryTestGenerator = new RepositoryTestGenerator($this->commandData);
+        /** @var RepositoryTestGenerator $repositoryGenerator */
+        $repositoryTestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.repository_test', [$this->commandData]);
         $repositoryTestGenerator->generate();
 
-        $testTraitGenerator = new TestTraitGenerator($this->commandData);
+        /** @var TestTraitGenerator $testTraitGenerator */
+        $testTraitGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.test_trait', [$this->commandData]);
         $testTraitGenerator->generate();
 
         $apiTestGenerator = new APITestGenerator($this->commandData);

--- a/src/Commands/APIScaffoldGeneratorCommand.php
+++ b/src/Commands/APIScaffoldGeneratorCommand.php
@@ -2,6 +2,7 @@
 
 namespace InfyOm\Generator\Commands;
 
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 
 class APIScaffoldGeneratorCommand extends BaseCommand
@@ -22,12 +23,12 @@ class APIScaffoldGeneratorCommand extends BaseCommand
 
     /**
      * Create a new command instance.
+     * @throws \ReflectionException
      */
     public function __construct()
     {
         parent::__construct();
-
-        $this->commandData = new CommandData($this, CommandData::$COMMAND_TYPE_API_SCAFFOLD);
+        $this->commandData = ClassInjectionConfig::createClassByConfigPath('Common.command_data', [$this, CommandData::$COMMAND_TYPE_API_SCAFFOLD]);
     }
 
     /**

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Commands;
 
 use Illuminate\Console\Command;
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\API\APIControllerGenerator;
 use InfyOm\Generator\Generators\API\APIRequestGenerator;
@@ -54,24 +55,33 @@ class BaseCommand extends Command
         $this->commandData->getFields();
     }
 
+    /**
+     * @throws \Exception
+     */
     public function generateCommonItems()
     {
         if (!$this->commandData->getOption('fromTable') and !$this->isSkip('migration')) {
-            $migrationGenerator = new MigrationGenerator($this->commandData);
+            /** @var MigrationGenerator $migrationGenerator */
+            $migrationGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.migration', [$this->commandData]);
             $migrationGenerator->generate();
         }
 
         if (!$this->isSkip('model')) {
-            $modelGenerator = new ModelGenerator($this->commandData);
+            /** @var ModelGenerator $modelGenerator */
+            $modelGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.model', [$this->commandData]);
             $modelGenerator->generate();
         }
 
         if (!$this->isSkip('repository')) {
-            $repositoryGenerator = new RepositoryGenerator($this->commandData);
+            /** @var RepositoryGenerator $repositoryGenerator */
+            $repositoryGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.repository', [$this->commandData]);
             $repositoryGenerator->generate();
         }
     }
 
+    /**
+     * @throws \ReflectionException
+     */
     public function generateAPIItems()
     {
         if (!$this->isSkip('requests') and !$this->isSkip('api_requests')) {
@@ -90,10 +100,12 @@ class BaseCommand extends Command
         }
 
         if (!$this->isSkip('tests') and $this->commandData->getAddOn('tests')) {
-            $repositoryTestGenerator = new RepositoryTestGenerator($this->commandData);
+            /** @var RepositoryTestGenerator $repositoryGenerator */
+            $repositoryTestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.repository_test', [$this->commandData]);
             $repositoryTestGenerator->generate();
 
-            $testTraitGenerator = new TestTraitGenerator($this->commandData);
+            /** @var TestTraitGenerator $testTraitGenerator */
+            $testTraitGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.test_trait', [$this->commandData]);
             $testTraitGenerator->generate();
 
             $apiTestGenerator = new APITestGenerator($this->commandData);

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -117,30 +117,38 @@ class BaseCommand extends Command
         }
     }
 
+    /**
+     * @throws \ReflectionException
+     */
     public function generateScaffoldItems()
     {
         if (!$this->isSkip('requests') and !$this->isSkip('scaffold_requests')) {
-            $requestGenerator = new RequestGenerator($this->commandData);
+            /** @var RequestGenerator $requestGenerator */
+            $requestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.request', [$this->commandData]);
             $requestGenerator->generate();
         }
 
         if (!$this->isSkip('controllers') and !$this->isSkip('scaffold_controller')) {
-            $controllerGenerator = new ControllerGenerator($this->commandData);
+            /** @var ControllerGenerator $controllerGenerator */
+            $controllerGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.controller', [$this->commandData]);
             $controllerGenerator->generate();
         }
 
         if (!$this->isSkip('views')) {
-            $viewGenerator = new ViewGenerator($this->commandData);
+            /** @var ViewGenerator $viewGenerator */
+            $viewGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.view', [$this->commandData]);
             $viewGenerator->generate();
         }
 
         if (!$this->isSkip('routes') and !$this->isSkip('scaffold_routes')) {
-            $routeGenerator = new RoutesGenerator($this->commandData);
+            /** @var RoutesGenerator $routeGenerator */
+            $routeGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.routes', [$this->commandData]);
             $routeGenerator->generate();
         }
 
         if (!$this->isSkip('menu') and $this->commandData->config->getAddOn('menu.enabled')) {
-            $menuGenerator = new MenuGenerator($this->commandData);
+            /** @var MenuGenerator $menuGenerator */
+            $menuGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.menu', [$this->commandData]);
             $menuGenerator->generate();
         }
     }

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -85,17 +85,20 @@ class BaseCommand extends Command
     public function generateAPIItems()
     {
         if (!$this->isSkip('requests') and !$this->isSkip('api_requests')) {
-            $requestGenerator = new APIRequestGenerator($this->commandData);
+            /** @var APIRequestGenerator $requestGenerator */
+            $requestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_request', [$this->commandData]);
             $requestGenerator->generate();
         }
 
         if (!$this->isSkip('controllers') and !$this->isSkip('api_controller')) {
-            $controllerGenerator = new APIControllerGenerator($this->commandData);
+            /** @var APIControllerGenerator $controllerGenerator */
+            $controllerGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_controller', [$this->commandData]);
             $controllerGenerator->generate();
         }
 
         if (!$this->isSkip('routes') and !$this->isSkip('api_routes')) {
-            $routesGenerator = new APIRoutesGenerator($this->commandData);
+            /** @var APIRoutesGenerator $routesGenerator */
+            $routesGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_routes', [$this->commandData]);
             $routesGenerator->generate();
         }
 
@@ -108,7 +111,8 @@ class BaseCommand extends Command
             $testTraitGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.test_trait', [$this->commandData]);
             $testTraitGenerator->generate();
 
-            $apiTestGenerator = new APITestGenerator($this->commandData);
+            /** @var APITestGenerator $apiTestGenerator */
+            $apiTestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_test', [$this->commandData]);
             $apiTestGenerator->generate();
         }
     }

--- a/src/Commands/Common/MigrationGeneratorCommand.php
+++ b/src/Commands/Common/MigrationGeneratorCommand.php
@@ -25,12 +25,13 @@ class MigrationGeneratorCommand extends BaseCommand
 
     /**
      * Create a new command instance.
+     * @throws \ReflectionException
      */
     public function __construct()
     {
         parent::__construct();
 
-        $this->commandData = new CommandData($this, CommandData::$COMMAND_TYPE_API);
+        $this->commandData = ClassInjectionConfig::createClassByConfigPath('Common.command_data', [$this, CommandData::$COMMAND_TYPE_API]);
     }
 
     /**

--- a/src/Commands/Common/MigrationGeneratorCommand.php
+++ b/src/Commands/Common/MigrationGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Commands\Common;
 
 use InfyOm\Generator\Commands\BaseCommand;
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\MigrationGenerator;
 
@@ -36,6 +37,7 @@ class MigrationGeneratorCommand extends BaseCommand
      * Execute the command.
      *
      * @return void
+     * @throws \ReflectionException
      */
     public function handle()
     {
@@ -47,7 +49,8 @@ class MigrationGeneratorCommand extends BaseCommand
             return;
         }
 
-        $migrationGenerator = new MigrationGenerator($this->commandData);
+        /** @var MigrationGenerator $migrationGenerator */
+        $migrationGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.migration', [$this->commandData]);
         $migrationGenerator->generate();
 
         $this->performPostActionsWithMigration();

--- a/src/Commands/Common/ModelGeneratorCommand.php
+++ b/src/Commands/Common/ModelGeneratorCommand.php
@@ -25,12 +25,13 @@ class ModelGeneratorCommand extends BaseCommand
 
     /**
      * Create a new command instance.
+     * @throws \ReflectionException
      */
     public function __construct()
     {
         parent::__construct();
 
-        $this->commandData = new CommandData($this, CommandData::$COMMAND_TYPE_API);
+        $this->commandData = ClassInjectionConfig::createClassByConfigPath('Common.command_data', [$this, CommandData::$COMMAND_TYPE_API]);
     }
 
     /**

--- a/src/Commands/Common/ModelGeneratorCommand.php
+++ b/src/Commands/Common/ModelGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Commands\Common;
 
 use InfyOm\Generator\Commands\BaseCommand;
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\ModelGenerator;
 
@@ -36,12 +37,14 @@ class ModelGeneratorCommand extends BaseCommand
      * Execute the command.
      *
      * @return void
+     * @throws \Exception
      */
     public function handle()
     {
         parent::handle();
 
-        $modelGenerator = new ModelGenerator($this->commandData);
+        /** @var ModelGenerator $modelGenerator */
+        $modelGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.model', [$this->commandData]);
         $modelGenerator->generate();
 
         $this->performPostActions();

--- a/src/Commands/Common/RepositoryGeneratorCommand.php
+++ b/src/Commands/Common/RepositoryGeneratorCommand.php
@@ -25,12 +25,13 @@ class RepositoryGeneratorCommand extends BaseCommand
 
     /**
      * Create a new command instance.
+     * @throws \ReflectionException
      */
     public function __construct()
     {
         parent::__construct();
 
-        $this->commandData = new CommandData($this, CommandData::$COMMAND_TYPE_API);
+        $this->commandData = ClassInjectionConfig::createClassByConfigPath('Common.command_data', [$this, CommandData::$COMMAND_TYPE_API]);
     }
 
     /**

--- a/src/Commands/Common/RepositoryGeneratorCommand.php
+++ b/src/Commands/Common/RepositoryGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Commands\Common;
 
 use InfyOm\Generator\Commands\BaseCommand;
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\RepositoryGenerator;
 
@@ -36,12 +37,14 @@ class RepositoryGeneratorCommand extends BaseCommand
      * Execute the command.
      *
      * @return void
+     * @throws \ReflectionException
      */
     public function handle()
     {
         parent::handle();
 
-        $repositoryGenerator = new RepositoryGenerator($this->commandData);
+        /** @var RepositoryGenerator $repositoryGenerator */
+        $repositoryGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.repository', [$this->commandData]);
         $repositoryGenerator->generate();
 
         $this->performPostActions();

--- a/src/Commands/RollbackGeneratorCommand.php
+++ b/src/Commands/RollbackGeneratorCommand.php
@@ -79,7 +79,7 @@ class RollbackGeneratorCommand extends Command
             $this->error('invalid rollback type');
         }
 
-        $this->commandData = new CommandData($this, $this->argument('type'));
+        $this->commandData = ClassInjectionConfig::createClassByConfigPath('Common.command_data', [$this, $this->argument('type')]);
         $this->commandData->config->mName = $this->commandData->modelName = $this->argument('model');
 
         $this->commandData->config->init($this->commandData, ['tableName', 'prefix']);

--- a/src/Commands/RollbackGeneratorCommand.php
+++ b/src/Commands/RollbackGeneratorCommand.php
@@ -96,13 +96,16 @@ class RollbackGeneratorCommand extends Command
         $repositoryGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.repository', [$this->commandData]);
         $repositoryGenerator->rollback();
 
-        $requestGenerator = new APIRequestGenerator($this->commandData);
+        /** @var APIRequestGenerator $requestGenerator */
+        $requestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_request', [$this->commandData]);
         $requestGenerator->rollback();
 
-        $controllerGenerator = new APIControllerGenerator($this->commandData);
+        /** @var APIControllerGenerator $controllerGenerator */
+        $controllerGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_controller', [$this->commandData]);
         $controllerGenerator->rollback();
 
-        $routesGenerator = new APIRoutesGenerator($this->commandData);
+        /** @var APIRoutesGenerator $routesGenerator */
+        $routesGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_routes', [$this->commandData]);
         $routesGenerator->rollback();
 
         $requestGenerator = new RequestGenerator($this->commandData);
@@ -138,7 +141,8 @@ class RollbackGeneratorCommand extends Command
             $testTraitGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.test_trait', [$this->commandData]);
             $testTraitGenerator->rollback();
 
-            $apiTestGenerator = new APITestGenerator($this->commandData);
+            /** @var APITestGenerator $apiTestGenerator */
+            $apiTestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_test', [$this->commandData]);
             $apiTestGenerator->rollback();
         }
 

--- a/src/Commands/RollbackGeneratorCommand.php
+++ b/src/Commands/RollbackGeneratorCommand.php
@@ -124,16 +124,20 @@ class RollbackGeneratorCommand extends Command
         $routeGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.routes', [$this->commandData]);
         $routeGenerator->rollback();
 
-        $controllerGenerator = new VueJsControllerGenerator($this->commandData);
+        /** @var VueJsControllerGenerator $controllerGenerator */
+        $controllerGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.VueJs.controller', [$this->commandData]);
         $controllerGenerator->rollback();
 
-        $routesGenerator = new VueJsRoutesGenerator($this->commandData);
+        /** @var VueJsRoutesGenerator $routesGenerator */
+        $routesGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.VueJs.routes', [$this->commandData]);
         $routesGenerator->rollback();
 
-        $viewGenerator = new VueJsViewGenerator($this->commandData);
+        /** @var VueJsViewGenerator $routesGenerator */
+        $viewGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.VueJs.view', [$this->commandData]);
         $viewGenerator->rollback();
 
-        $modelJsConfigGenerator = new ModelJsConfigGenerator($this->commandData);
+        /** @var ModelJsConfigGenerator $modelJsConfigGenerator */
+        $modelJsConfigGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.VueJs.model_js_config', [$this->commandData]);
         $modelJsConfigGenerator->rollback();
 
         if ($this->commandData->getAddOn('tests')) {

--- a/src/Commands/RollbackGeneratorCommand.php
+++ b/src/Commands/RollbackGeneratorCommand.php
@@ -108,16 +108,20 @@ class RollbackGeneratorCommand extends Command
         $routesGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_routes', [$this->commandData]);
         $routesGenerator->rollback();
 
-        $requestGenerator = new RequestGenerator($this->commandData);
+        /** @var RequestGenerator $requestGenerator */
+        $requestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.request', [$this->commandData]);
         $requestGenerator->rollback();
 
-        $controllerGenerator = new ControllerGenerator($this->commandData);
+        /** @var ControllerGenerator $controllerGenerator */
+        $controllerGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.controller', [$this->commandData]);
         $controllerGenerator->rollback();
 
-        $viewGenerator = new ViewGenerator($this->commandData);
+        /** @var ViewGenerator $viewGenerator */
+        $viewGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.view', [$this->commandData]);
         $viewGenerator->rollback();
 
-        $routeGenerator = new RoutesGenerator($this->commandData);
+        /** @var RoutesGenerator $routeGenerator */
+        $routeGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.routes', [$this->commandData]);
         $routeGenerator->rollback();
 
         $controllerGenerator = new VueJsControllerGenerator($this->commandData);
@@ -147,7 +151,8 @@ class RollbackGeneratorCommand extends Command
         }
 
         if ($this->commandData->config->getAddOn('menu.enabled')) {
-            $menuGenerator = new MenuGenerator($this->commandData);
+            /** @var MenuGenerator $menuGenerator */
+            $menuGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.menu', [$this->commandData]);
             $menuGenerator->rollback();
         }
 

--- a/src/Commands/RollbackGeneratorCommand.php
+++ b/src/Commands/RollbackGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Commands;
 
 use Illuminate\Console\Command;
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\API\APIControllerGenerator;
 use InfyOm\Generator\Generators\API\APIRequestGenerator;
@@ -65,6 +66,7 @@ class RollbackGeneratorCommand extends Command
      * Execute the command.
      *
      * @return void
+     * @throws \Exception
      */
     public function handle()
     {
@@ -82,13 +84,16 @@ class RollbackGeneratorCommand extends Command
 
         $this->commandData->config->init($this->commandData, ['tableName', 'prefix']);
 
-        $migrationGenerator = new MigrationGenerator($this->commandData);
+        /** @var MigrationGenerator $migrationGenerator */
+        $migrationGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.migration', [$this->commandData]);
         $migrationGenerator->rollback();
 
-        $modelGenerator = new ModelGenerator($this->commandData);
+        /** @var ModelGenerator $modelGenerator */
+        $modelGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.model', [$this->commandData]);
         $modelGenerator->rollback();
 
-        $repositoryGenerator = new RepositoryGenerator($this->commandData);
+        /** @var RepositoryGenerator $repositoryGenerator */
+        $repositoryGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.repository', [$this->commandData]);
         $repositoryGenerator->rollback();
 
         $requestGenerator = new APIRequestGenerator($this->commandData);
@@ -125,10 +130,12 @@ class RollbackGeneratorCommand extends Command
         $modelJsConfigGenerator->rollback();
 
         if ($this->commandData->getAddOn('tests')) {
-            $repositoryTestGenerator = new RepositoryTestGenerator($this->commandData);
+            /** @var RepositoryTestGenerator $repositoryGenerator */
+            $repositoryTestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.repository_test', [$this->commandData]);
             $repositoryTestGenerator->rollback();
 
-            $testTraitGenerator = new TestTraitGenerator($this->commandData);
+            /** @var TestTraitGenerator $testTraitGenerator */
+            $testTraitGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.test_trait', [$this->commandData]);
             $testTraitGenerator->rollback();
 
             $apiTestGenerator = new APITestGenerator($this->commandData);

--- a/src/Commands/Scaffold/ControllerGeneratorCommand.php
+++ b/src/Commands/Scaffold/ControllerGeneratorCommand.php
@@ -25,12 +25,13 @@ class ControllerGeneratorCommand extends BaseCommand
 
     /**
      * Create a new command instance.
+     * @throws \ReflectionException
      */
     public function __construct()
     {
         parent::__construct();
 
-        $this->commandData = new CommandData($this, CommandData::$COMMAND_TYPE_SCAFFOLD);
+        $this->commandData = ClassInjectionConfig::createClassByConfigPath('Common.command_data', [$this, CommandData::$COMMAND_TYPE_SCAFFOLD]);
     }
 
     /**

--- a/src/Commands/Scaffold/ControllerGeneratorCommand.php
+++ b/src/Commands/Scaffold/ControllerGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Commands\Scaffold;
 
 use InfyOm\Generator\Commands\BaseCommand;
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\Scaffold\ControllerGenerator;
 
@@ -36,12 +37,14 @@ class ControllerGeneratorCommand extends BaseCommand
      * Execute the command.
      *
      * @return void
+     * @throws \ReflectionException
      */
     public function handle()
     {
         parent::handle();
 
-        $controllerGenerator = new ControllerGenerator($this->commandData);
+        /** @var ControllerGenerator $controllerGenerator */
+        $controllerGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.controller', [$this->commandData]);
         $controllerGenerator->generate();
 
         $this->performPostActions();

--- a/src/Commands/Scaffold/RequestsGeneratorCommand.php
+++ b/src/Commands/Scaffold/RequestsGeneratorCommand.php
@@ -25,12 +25,13 @@ class RequestsGeneratorCommand extends BaseCommand
 
     /**
      * Create a new command instance.
+     * @throws \ReflectionException
      */
     public function __construct()
     {
         parent::__construct();
 
-        $this->commandData = new CommandData($this, CommandData::$COMMAND_TYPE_SCAFFOLD);
+        $this->commandData = ClassInjectionConfig::createClassByConfigPath('Common.command_data', [$this, CommandData::$COMMAND_TYPE_SCAFFOLD]);
     }
 
     /**

--- a/src/Commands/Scaffold/RequestsGeneratorCommand.php
+++ b/src/Commands/Scaffold/RequestsGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Commands\Scaffold;
 
 use InfyOm\Generator\Commands\BaseCommand;
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\Scaffold\RequestGenerator;
 
@@ -36,12 +37,14 @@ class RequestsGeneratorCommand extends BaseCommand
      * Execute the command.
      *
      * @return void
+     * @throws \ReflectionException
      */
     public function handle()
     {
         parent::handle();
 
-        $requestGenerator = new RequestGenerator($this->commandData);
+        /** @var RequestGenerator $requestGenerator */
+        $requestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.request', [$this->commandData]);
         $requestGenerator->generate();
 
         $this->performPostActions();

--- a/src/Commands/Scaffold/ScaffoldGeneratorCommand.php
+++ b/src/Commands/Scaffold/ScaffoldGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Commands\Scaffold;
 
 use InfyOm\Generator\Commands\BaseCommand;
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 
 class ScaffoldGeneratorCommand extends BaseCommand
@@ -23,12 +24,13 @@ class ScaffoldGeneratorCommand extends BaseCommand
 
     /**
      * Create a new command instance.
+     * @throws \ReflectionException
      */
     public function __construct()
     {
         parent::__construct();
 
-        $this->commandData = new CommandData($this, CommandData::$COMMAND_TYPE_SCAFFOLD);
+        $this->commandData = ClassInjectionConfig::createClassByConfigPath('Common.command_data', [$this, CommandData::$COMMAND_TYPE_SCAFFOLD]);
     }
 
     /**

--- a/src/Commands/Scaffold/ViewsGeneratorCommand.php
+++ b/src/Commands/Scaffold/ViewsGeneratorCommand.php
@@ -25,12 +25,13 @@ class ViewsGeneratorCommand extends BaseCommand
 
     /**
      * Create a new command instance.
+     * @throws \ReflectionException
      */
     public function __construct()
     {
         parent::__construct();
 
-        $this->commandData = new CommandData($this, CommandData::$COMMAND_TYPE_SCAFFOLD);
+        $this->commandData = ClassInjectionConfig::createClassByConfigPath('Common.command_data', [$this, CommandData::$COMMAND_TYPE_SCAFFOLD]);
     }
 
     /**

--- a/src/Commands/Scaffold/ViewsGeneratorCommand.php
+++ b/src/Commands/Scaffold/ViewsGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Commands\Scaffold;
 
 use InfyOm\Generator\Commands\BaseCommand;
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\Scaffold\ViewGenerator;
 
@@ -36,12 +37,14 @@ class ViewsGeneratorCommand extends BaseCommand
      * Execute the command.
      *
      * @return void
+     * @throws \ReflectionException
      */
     public function handle()
     {
         parent::handle();
 
-        $viewGenerator = new ViewGenerator($this->commandData);
+        /** @var ViewGenerator $viewGenerator */
+        $viewGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.view', [$this->commandData]);
         $viewGenerator->generate();
 
         $this->performPostActions();

--- a/src/Commands/VueJs/VueJsGeneratorCommand.php
+++ b/src/Commands/VueJs/VueJsGeneratorCommand.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Commands\VueJs;
 
 use InfyOm\Generator\Commands\BaseCommand;
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\MigrationGenerator;
 use InfyOm\Generator\Generators\ModelGenerator;
@@ -44,20 +45,24 @@ class VueJsGeneratorCommand extends BaseCommand
      * Execute the command.
      *
      * @return void
+     * @throws \Exception
      */
     public function handle()
     {
         parent::handle();
 
         if (!$this->commandData->getOption('fromTable')) {
-            $migrationGenerator = new MigrationGenerator($this->commandData);
+            /** @var MigrationGenerator $migrationGenerator */
+            $migrationGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.migration', [$this->commandData]);
             $migrationGenerator->generate();
         }
 
-        $modelGenerator = new ModelGenerator($this->commandData);
+        /** @var ModelGenerator $modelGenerator */
+        $modelGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.model', [$this->commandData]);
         $modelGenerator->generate();
 
-        $repositoryGenerator = new RepositoryGenerator($this->commandData);
+        /** @var RepositoryGenerator $repositoryGenerator */
+        $repositoryGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.repository', [$this->commandData]);
         $repositoryGenerator->generate();
 
         $requestGenerator = new APIRequestGenerator($this->commandData);

--- a/src/Commands/VueJs/VueJsGeneratorCommand.php
+++ b/src/Commands/VueJs/VueJsGeneratorCommand.php
@@ -69,20 +69,24 @@ class VueJsGeneratorCommand extends BaseCommand
         $requestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_request', [$this->commandData]);
         $requestGenerator->generate();
 
-        $controllerGenerator = new ControllerGenerator($this->commandData);
+        /** @var ControllerGenerator $controllerGenerator */
+        $controllerGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.controller', [$this->commandData]);
         $controllerGenerator->generate();
 
-        $viewGenerator = new ViewGenerator($this->commandData);
+        /** @var ViewGenerator $viewGenerator */
+        $viewGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.view', [$this->commandData]);
         $viewGenerator->generate();
 
         $modelJsConfigGenerator = new ModelJsConfigGenerator($this->commandData);
         $modelJsConfigGenerator->generate();
 
-        $routeGenerator = new RoutesGenerator($this->commandData);
+        /** @var RoutesGenerator $routeGenerator */
+        $routeGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.routes', [$this->commandData]);
         $routeGenerator->generate();
 
         if ($this->commandData->config->getAddOn('menu.enabled')) {
-            $menuGenerator = new MenuGenerator($this->commandData);
+            /** @var MenuGenerator $menuGenerator */
+            $menuGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.menu', [$this->commandData]);
             $menuGenerator->generate();
         }
 

--- a/src/Commands/VueJs/VueJsGeneratorCommand.php
+++ b/src/Commands/VueJs/VueJsGeneratorCommand.php
@@ -33,12 +33,13 @@ class VueJsGeneratorCommand extends BaseCommand
 
     /**
      * Create a new command instance.
+     * @throws \ReflectionException
      */
     public function __construct()
     {
         parent::__construct();
 
-        $this->commandData = new CommandData($this, CommandData::$COMMAND_TYPE_VUEJS);
+        $this->commandData = ClassInjectionConfig::createClassByConfigPath('Common.command_data', [$this, CommandData::$COMMAND_TYPE_VUEJS]);
     }
 
     /**

--- a/src/Commands/VueJs/VueJsGeneratorCommand.php
+++ b/src/Commands/VueJs/VueJsGeneratorCommand.php
@@ -65,7 +65,8 @@ class VueJsGeneratorCommand extends BaseCommand
         $repositoryGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.repository', [$this->commandData]);
         $repositoryGenerator->generate();
 
-        $requestGenerator = new APIRequestGenerator($this->commandData);
+        /** @var APIRequestGenerator $requestGenerator */
+        $requestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_request', [$this->commandData]);
         $requestGenerator->generate();
 
         $controllerGenerator = new ControllerGenerator($this->commandData);

--- a/src/Commands/VueJs/VueJsGeneratorCommand.php
+++ b/src/Commands/VueJs/VueJsGeneratorCommand.php
@@ -66,22 +66,24 @@ class VueJsGeneratorCommand extends BaseCommand
         $repositoryGenerator->generate();
 
         /** @var APIRequestGenerator $requestGenerator */
-        $requestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.API.api_request', [$this->commandData]);
+        $requestGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.VueJs.api_request', [$this->commandData]);
         $requestGenerator->generate();
 
         /** @var ControllerGenerator $controllerGenerator */
-        $controllerGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.controller', [$this->commandData]);
+        $controllerGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.VueJs.controller', [$this->commandData]);
         $controllerGenerator->generate();
 
         /** @var ViewGenerator $viewGenerator */
-        $viewGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.view', [$this->commandData]);
+        $viewGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.VueJs.view', [$this->commandData]);
         $viewGenerator->generate();
 
-        $modelJsConfigGenerator = new ModelJsConfigGenerator($this->commandData);
+
+        /** @var ModelJsConfigGenerator $modelJsConfigGenerator */
+        $modelJsConfigGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.VueJs.model_js_config', [$this->commandData]);
         $modelJsConfigGenerator->generate();
 
         /** @var RoutesGenerator $routeGenerator */
-        $routeGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.Scaffold.routes', [$this->commandData]);
+        $routeGenerator = ClassInjectionConfig::createClassByConfigPath('Generators.VueJs.routes', [$this->commandData]);
         $routeGenerator->generate();
 
         if ($this->commandData->config->getAddOn('menu.enabled')) {

--- a/src/Common/ClassInjectionConfig.php
+++ b/src/Common/ClassInjectionConfig.php
@@ -13,6 +13,12 @@ class ClassInjectionConfig
      * @var array The default classes we'll draw from if we have no overrides
      */
     private static $defaultClasses = [
+        'Common' => [
+            'command_data' => \InfyOm\Generator\Common\CommandData::class,
+            'generator_config' => \InfyOm\Generator\Common\GeneratorConfig::class,
+            'generator_field' => \InfyOm\Generator\Common\GeneratorField::class,
+            'generator_field_relation' => \InfyOm\Generator\Common\GeneratorFieldRelation::class,
+        ],
         'Generators' => [
             'API' => [
                 'api_controller' => \InfyOm\Generator\Generators\API\APIControllerGenerator::class,

--- a/src/Common/ClassInjectionConfig.php
+++ b/src/Common/ClassInjectionConfig.php
@@ -41,7 +41,7 @@ class ClassInjectionConfig
 
         $class = array_get(static::$classes, $type);
         if(empty($class) || !class_exists($class)){
-            throw new \Exception('Classname for infyom.laravel_generator.classes.'.$type.' does not exist: '.$class);
+            throw new \RuntimeException('Classname for infyom.laravel_generator.classes.'.$type.' does not exist: '.$class);
         }
         return $class;
     }

--- a/src/Common/ClassInjectionConfig.php
+++ b/src/Common/ClassInjectionConfig.php
@@ -20,6 +20,13 @@ class ClassInjectionConfig
                 'api_routes' => \InfyOm\Generator\Generators\API\APIRoutesGenerator::class,
                 'api_test' => \InfyOm\Generator\Generators\API\APITestGenerator::class,
             ],
+            'Scaffold' => [
+                'controller' =>  \InfyOm\Generator\Generators\Scaffold\ControllerGenerator::class,
+                'menu' =>  \InfyOm\Generator\Generators\Scaffold\MenuGenerator::class,
+                'request' =>  \InfyOm\Generator\Generators\Scaffold\RequestGenerator::class,
+                'routes' =>  \InfyOm\Generator\Generators\Scaffold\RoutesGenerator::class,
+                'view' =>  \InfyOm\Generator\Generators\Scaffold\ViewGenerator::class,
+            ],
             'migration' => \InfyOm\Generator\Generators\MigrationGenerator::class,
             'model' => \InfyOm\Generator\Generators\ModelGenerator::class,
             'repository' => \InfyOm\Generator\Generators\RepositoryGenerator::class,

--- a/src/Common/ClassInjectionConfig.php
+++ b/src/Common/ClassInjectionConfig.php
@@ -51,6 +51,9 @@ class ClassInjectionConfig
             'repository_test' => \InfyOm\Generator\Generators\RepositoryTestGenerator::class,
             'swagger' => \InfyOm\Generator\Generators\SwaggerGenerator::class,
             'test_trait' => \InfyOm\Generator\Generators\TestTraitGenerator::class
+        ],
+        'Utils' => [
+            'table_field_generator' => \InfyOm\Generator\Utils\TableFieldsGenerator::class
         ]
     ];
 

--- a/src/Common/ClassInjectionConfig.php
+++ b/src/Common/ClassInjectionConfig.php
@@ -6,6 +6,9 @@ namespace InfyOm\Generator\Common;
 /**
  * Class ClassInjectionConfig
  * @package InfyOm\Generator\Common
+ *
+ * This class handles all class injections for this library, and provides a mechanism for developers extend & inject
+ * their own classes into this library.  This class is designed to make this code base much more configurable.
  */
 class ClassInjectionConfig
 {

--- a/src/Common/ClassInjectionConfig.php
+++ b/src/Common/ClassInjectionConfig.php
@@ -27,6 +27,15 @@ class ClassInjectionConfig
                 'routes' =>  \InfyOm\Generator\Generators\Scaffold\RoutesGenerator::class,
                 'view' =>  \InfyOm\Generator\Generators\Scaffold\ViewGenerator::class,
             ],
+            'VueJs' => [
+                'api_request' => \InfyOm\Generator\Generators\VueJs\APIRequestGenerator::class,
+                'controller' => \InfyOm\Generator\Generators\VueJs\ControllerGenerator::class,
+                'model_js_config' => \InfyOm\Generator\Generators\VueJs\ModelJsConfigGenerator::class,
+                'routes' => \InfyOm\Generator\Generators\Vuejs\RoutesGenerator::class,
+                'test' => \InfyOm\Generator\Generators\API\TestGenerator::class,
+                'view' => \InfyOm\Generator\Generators\VueJs\ViewGenerator::class,
+
+            ],
             'migration' => \InfyOm\Generator\Generators\MigrationGenerator::class,
             'model' => \InfyOm\Generator\Generators\ModelGenerator::class,
             'repository' => \InfyOm\Generator\Generators\RepositoryGenerator::class,

--- a/src/Common/ClassInjectionConfig.php
+++ b/src/Common/ClassInjectionConfig.php
@@ -2,6 +2,7 @@
 
 namespace InfyOm\Generator\Common;
 
+
 /**
  * Class ClassInjectionConfig
  * @package InfyOm\Generator\Common
@@ -13,6 +14,12 @@ class ClassInjectionConfig
      */
     private static $defaultClasses = [
         'Generators' => [
+            'API' => [
+                'api_controller' => \InfyOm\Generator\Generators\API\APIControllerGenerator::class,
+                'api_request' => \InfyOm\Generator\Generators\API\APIRequestGenerator::class,
+                'api_routes' => \InfyOm\Generator\Generators\API\APIRoutesGenerator::class,
+                'api_test' => \InfyOm\Generator\Generators\API\APITestGenerator::class,
+            ],
             'migration' => \InfyOm\Generator\Generators\MigrationGenerator::class,
             'model' => \InfyOm\Generator\Generators\ModelGenerator::class,
             'repository' => \InfyOm\Generator\Generators\RepositoryGenerator::class,

--- a/src/Common/ClassInjectionConfig.php
+++ b/src/Common/ClassInjectionConfig.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace InfyOm\Generator\Common;
+
+/**
+ * Class ClassInjectionConfig
+ * @package InfyOm\Generator\Common
+ */
+class ClassInjectionConfig
+{
+    /**
+     * @var array The default classes we'll draw from if we have no overrides
+     */
+    private static $defaultClasses = [
+        'Generators' => [
+            'migration' => \InfyOm\Generator\Generators\MigrationGenerator::class,
+            'model' => \InfyOm\Generator\Generators\ModelGenerator::class,
+            'repository' => \InfyOm\Generator\Generators\RepositoryGenerator::class,
+            'repository_test' => \InfyOm\Generator\Generators\RepositoryTestGenerator::class,
+            'swagger' => \InfyOm\Generator\Generators\SwaggerGenerator::class,
+            'test_trait' => \InfyOm\Generator\Generators\TestTraitGenerator::class
+        ]
+    ];
+
+    /**
+     * @var array A merge of our default classes and those defined in a config file
+     */
+    private static $classes = [];
+
+    /**
+     * This gets the class we need from the config (laravel_generator.php => 'classes')
+     * @param $type string class we need in dot notation staring from laravel_generator.php => 'classes', e.g. 'Generators.model'
+     * @return mixed
+     * @throws \Exception
+     */
+    public static function getClassByConfigPath($type)
+    {
+        if(empty(static::$classes)){
+            static::populateClasses();
+        }
+
+        $class = array_get(static::$classes, $type);
+        if(empty($class) || !class_exists($class)){
+            throw new \Exception('Classname for infyom.laravel_generator.classes.'.$type.' does not exist: '.$class);
+        }
+        return $class;
+    }
+
+    /**
+     * Creates a class with config path + arguments
+     * @param $type string
+     * @param $arguments array
+     * @return object
+     * @throws \ReflectionException
+     * @throws \Exception
+     */
+    public static function createClassByConfigPath($type, $arguments = [])
+    {
+        $reflection = new \ReflectionClass(static::getClassByConfigPath($type));
+        return $reflection->newInstanceArgs($arguments);
+    }
+
+    /**
+     * Populates our classes array by merging the config with the defaults in this static class
+     */
+    private static function populateClasses(): void
+    {
+        static::$classes = array_replace_recursive(static::$defaultClasses, config('infyom.laravel_generator.classes', []));
+    }
+}

--- a/src/Common/CommandData.php
+++ b/src/Common/CommandData.php
@@ -123,7 +123,7 @@ class CommandData
      * @throws \ReflectionException
      * @throws Exception
      */
-    private function getInputFromConsole()
+    protected function getInputFromConsole()
     {
         $this->commandInfo('Specify fields for the model (skip id & timestamp fields, we will add it automatically)');
         $this->commandInfo('Read docs carefully to specify field inputs)');
@@ -171,7 +171,7 @@ class CommandData
     /**
      * @throws \ReflectionException
      */
-    private function addPrimaryKey()
+    protected function addPrimaryKey()
     {
         /** @var GeneratorField $primaryKey */
         $primaryKey = ClassInjectionConfig::createClassByConfigPath('Common.generator_field');
@@ -189,7 +189,7 @@ class CommandData
     /**
      * @throws \ReflectionException
      */
-    private function addTimestamps()
+    protected function addTimestamps()
     {
         /** @var GeneratorField $createdAt */
         $createdAt = ClassInjectionConfig::createClassByConfigPath('Common.generator_field');
@@ -206,7 +206,7 @@ class CommandData
         $this->fields[] = $updatedAt;
     }
 
-    private function getInputFromFileOrJson()
+    protected function getInputFromFileOrJson()
     {
         // fieldsFile option will get high priority than json option if both options are passed
         try {
@@ -264,7 +264,7 @@ class CommandData
         }
     }
 
-    private function getInputFromTable()
+    protected function getInputFromTable()
     {
         $tableName = $this->dynamicVars['$TABLE_NAME$'];
 

--- a/src/Common/CommandData.php
+++ b/src/Common/CommandData.php
@@ -264,11 +264,16 @@ class CommandData
         }
     }
 
+    /**
+     * @throws \ReflectionException
+     */
     protected function getInputFromTable()
     {
         $tableName = $this->dynamicVars['$TABLE_NAME$'];
 
-        $tableFieldsGenerator = new TableFieldsGenerator($tableName);
+
+        /** @var TableFieldsGenerator $tableFieldsGenerator */
+        $tableFieldsGenerator = ClassInjectionConfig::createClassByConfigPath('Utils.table_field_generator', [$tableName]);
         $tableFieldsGenerator->prepareFieldsFromTable();
         $tableFieldsGenerator->prepareRelations();
 

--- a/src/Common/GeneratorField.php
+++ b/src/Common/GeneratorField.php
@@ -124,7 +124,7 @@ class GeneratorField
 
     public static function parseFieldFromFile($fieldInput)
     {
-        $field = new self();
+        $field = new static();
         $field->name = $fieldInput['name'];
         $field->parseDBType($fieldInput['dbType']);
         $field->parseHtmlInput(isset($fieldInput['htmlType']) ? $fieldInput['htmlType'] : '');

--- a/src/Common/GeneratorField.php
+++ b/src/Common/GeneratorField.php
@@ -80,7 +80,7 @@ class GeneratorField
         }
     }
 
-    private function prepareMigrationText()
+    protected function prepareMigrationText()
     {
         $inputsArr = explode(':', $this->dbInput);
         $this->migrationText = '$table->';

--- a/src/Common/GeneratorFieldRelation.php
+++ b/src/Common/GeneratorFieldRelation.php
@@ -12,7 +12,7 @@ class GeneratorFieldRelation
     {
         $inputs = explode(',', $relationInput);
 
-        $relation = new self();
+        $relation = new static();
         $relation->type = array_shift($inputs);
         $relation->inputs = $inputs;
 

--- a/src/Common/GeneratorFieldRelation.php
+++ b/src/Common/GeneratorFieldRelation.php
@@ -62,7 +62,7 @@ class GeneratorFieldRelation
         return '';
     }
 
-    private function generateRelation($functionName, $relation, $relationClass)
+    protected function generateRelation($functionName, $relation, $relationClass)
     {
         $inputs = $this->inputs;
         $modelName = array_shift($inputs);

--- a/src/Generators/API/APIControllerGenerator.php
+++ b/src/Generators/API/APIControllerGenerator.php
@@ -9,13 +9,13 @@ use InfyOm\Generator\Utils\FileUtil;
 class APIControllerGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $fileName;
+    protected $fileName;
 
     public function __construct(CommandData $commandData)
     {
@@ -37,7 +37,7 @@ class APIControllerGenerator extends BaseGenerator
         $this->commandData->commandInfo($this->fileName);
     }
 
-    private function fillDocs($templateData)
+    protected function fillDocs($templateData)
     {
         $methods = ['controller', 'index', 'store', 'show', 'update', 'destroy'];
 

--- a/src/Generators/API/APIRequestGenerator.php
+++ b/src/Generators/API/APIRequestGenerator.php
@@ -9,16 +9,16 @@ use InfyOm\Generator\Utils\FileUtil;
 class APIRequestGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $createFileName;
+    protected $createFileName;
 
     /** @var string */
-    private $updateFileName;
+    protected $updateFileName;
 
     public function __construct(CommandData $commandData)
     {
@@ -34,7 +34,7 @@ class APIRequestGenerator extends BaseGenerator
         $this->generateUpdateRequest();
     }
 
-    private function generateCreateRequest()
+    protected function generateCreateRequest()
     {
         $templateData = get_template('api.request.create_request', 'laravel-generator');
 
@@ -46,7 +46,7 @@ class APIRequestGenerator extends BaseGenerator
         $this->commandData->commandInfo($this->createFileName);
     }
 
-    private function generateUpdateRequest()
+    protected function generateUpdateRequest()
     {
         $templateData = get_template('api.request.update_request', 'laravel-generator');
 

--- a/src/Generators/API/APIRoutesGenerator.php
+++ b/src/Generators/API/APIRoutesGenerator.php
@@ -9,16 +9,16 @@ use InfyOm\Generator\Generators\BaseGenerator;
 class APIRoutesGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $routeContents;
+    protected $routeContents;
 
     /** @var string */
-    private $routesTemplate;
+    protected $routesTemplate;
 
     public function __construct(CommandData $commandData)
     {

--- a/src/Generators/API/APITestGenerator.php
+++ b/src/Generators/API/APITestGenerator.php
@@ -9,13 +9,13 @@ use InfyOm\Generator\Utils\FileUtil;
 class APITestGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $fileName;
+    protected $fileName;
 
     public function __construct(CommandData $commandData)
     {

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -11,10 +11,10 @@ use SplFileInfo;
 class MigrationGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     public function __construct($commandData)
     {
@@ -40,7 +40,7 @@ class MigrationGenerator extends BaseGenerator
         $this->commandData->commandInfo($fileName);
     }
 
-    private function generateFields()
+    protected function generateFields()
     {
         $fields = [];
         $foreignKeys = [];

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -2,6 +2,7 @@
 
 namespace InfyOm\Generator\Generators;
 
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Common\GeneratorFieldRelation;
 use InfyOm\Generator\Utils\FileUtil;
@@ -169,9 +170,16 @@ class ModelGenerator extends BaseGenerator
         }
     }
 
+    /**
+     * @param $templateData
+     * @return mixed
+     * @throws \Exception
+     */
     public function generateSwagger($templateData)
     {
-        $fieldTypes = SwaggerGenerator::generateTypes($this->commandData->fields);
+        /** @var SwaggerGenerator $swaggerGeneratorClass */
+        $swaggerGeneratorClass = ClassInjectionConfig::getClassByConfigPath('Generators.swagger');
+        $fieldTypes = $swaggerGeneratorClass::generateTypes($this->commandData->fields);
 
         $template = get_template('model_docs.model', 'swagger-generator');
 
@@ -182,7 +190,7 @@ class ModelGenerator extends BaseGenerator
 
         $propertyTemplate = get_template('model_docs.property', 'swagger-generator');
 
-        $properties = SwaggerGenerator::preparePropertyFields($propertyTemplate, $fieldTypes);
+        $properties = $swaggerGeneratorClass::preparePropertyFields($propertyTemplate, $fieldTypes);
 
         $template = str_replace('$PROPERTIES$', implode(",\n", $properties), $template);
 

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -21,12 +21,12 @@ class ModelGenerator extends BaseGenerator
     ];
 
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
-    private $fileName;
-    private $table;
+    protected $path;
+    protected $fileName;
+    protected $table;
 
     /**
      * ModelGenerator constructor.
@@ -53,7 +53,7 @@ class ModelGenerator extends BaseGenerator
         $this->commandData->commandInfo($this->fileName);
     }
 
-    private function fillTemplate($templateData)
+    protected function fillTemplate($templateData)
     {
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
 
@@ -96,7 +96,7 @@ class ModelGenerator extends BaseGenerator
         return $templateData;
     }
 
-    private function fillSoftDeletes($templateData)
+    protected function fillSoftDeletes($templateData)
     {
         if (!$this->commandData->getOption('softDelete')) {
             $templateData = str_replace('$SOFT_DELETE_IMPORT$', '', $templateData);
@@ -118,7 +118,7 @@ class ModelGenerator extends BaseGenerator
         return $templateData;
     }
 
-    private function fillDocs($templateData)
+    protected function fillDocs($templateData)
     {
         if ($this->commandData->getAddOn('swagger')) {
             $templateData = $this->generateSwagger($templateData);
@@ -150,7 +150,7 @@ class ModelGenerator extends BaseGenerator
      *
      * @return string
      */
-    private function getPHPDocType($db_type, $relation = null)
+    protected function getPHPDocType($db_type, $relation = null)
     {
         switch ($db_type) {
             case 'datetime':
@@ -199,7 +199,7 @@ class ModelGenerator extends BaseGenerator
         return $templateData;
     }
 
-    private function generateRequiredFields()
+    protected function generateRequiredFields()
     {
         $requiredFields = [];
 
@@ -214,7 +214,7 @@ class ModelGenerator extends BaseGenerator
         return $requiredFields;
     }
 
-    private function fillTimestamps($templateData)
+    protected function fillTimestamps($templateData)
     {
         $timestamps = TableFieldsGenerator::getTimestampFieldNames();
 
@@ -236,7 +236,7 @@ class ModelGenerator extends BaseGenerator
         return str_replace('$TIMESTAMPS$', $replace, $templateData);
     }
 
-    private function generateRules()
+    protected function generateRules()
     {
         $rules = [];
 
@@ -302,7 +302,7 @@ class ModelGenerator extends BaseGenerator
         return $casts;
     }
 
-    private function generateRelations()
+    protected function generateRelations()
     {
         $relations = [];
 

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -214,9 +214,16 @@ class ModelGenerator extends BaseGenerator
         return $requiredFields;
     }
 
+    /**
+     * @param $templateData
+     * @return mixed
+     * @throws \Exception
+     */
     protected function fillTimestamps($templateData)
     {
-        $timestamps = TableFieldsGenerator::getTimestampFieldNames();
+        /** @var TableFieldsGenerator $tableFieldsGeneratorClass */
+        $tableFieldsGeneratorClass = ClassInjectionConfig::getClassByConfigPath('Utils.table_field_generator');
+        $timestamps = $tableFieldsGeneratorClass::getTimestampFieldNames();
 
         $replace = '';
 
@@ -250,11 +257,17 @@ class ModelGenerator extends BaseGenerator
         return $rules;
     }
 
+    /**
+     * @return array
+     * @throws \Exception
+     */
     public function generateCasts()
     {
         $casts = [];
 
-        $timestamps = TableFieldsGenerator::getTimestampFieldNames();
+        /** @var TableFieldsGenerator $tableFieldsGeneratorClass */
+        $tableFieldsGeneratorClass = ClassInjectionConfig::getClassByConfigPath('Utils.table_field_generator');
+        $timestamps = $tableFieldsGeneratorClass::getTimestampFieldNames();
 
         foreach ($this->commandData->fields as $field) {
             if (in_array($field->name, $timestamps)) {

--- a/src/Generators/RepositoryGenerator.php
+++ b/src/Generators/RepositoryGenerator.php
@@ -8,13 +8,13 @@ use InfyOm\Generator\Utils\FileUtil;
 class RepositoryGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $fileName;
+    protected $fileName;
 
     public function __construct(CommandData $commandData)
     {

--- a/src/Generators/RepositoryTestGenerator.php
+++ b/src/Generators/RepositoryTestGenerator.php
@@ -8,13 +8,13 @@ use InfyOm\Generator\Utils\FileUtil;
 class RepositoryTestGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $fileName;
+    protected $fileName;
 
     public function __construct($commandData)
     {
@@ -35,7 +35,7 @@ class RepositoryTestGenerator extends BaseGenerator
         $this->commandData->commandObj->info($this->fileName);
     }
 
-    private function fillTemplate($templateData)
+    protected function fillTemplate($templateData)
     {
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
 

--- a/src/Generators/Scaffold/ControllerGenerator.php
+++ b/src/Generators/Scaffold/ControllerGenerator.php
@@ -9,16 +9,16 @@ use InfyOm\Generator\Utils\FileUtil;
 class ControllerGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $templateType;
+    protected $templateType;
 
     /** @var string */
-    private $fileName;
+    protected $fileName;
 
     public function __construct(CommandData $commandData)
     {
@@ -54,7 +54,7 @@ class ControllerGenerator extends BaseGenerator
         $this->commandData->commandInfo($this->fileName);
     }
 
-    private function generateDataTable()
+    protected function generateDataTable()
     {
         $templateData = get_template('scaffold.datatable', 'laravel-generator');
 

--- a/src/Generators/Scaffold/MenuGenerator.php
+++ b/src/Generators/Scaffold/MenuGenerator.php
@@ -9,19 +9,19 @@ use InfyOm\Generator\Generators\BaseGenerator;
 class MenuGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $templateType;
+    protected $templateType;
 
     /** @var string */
-    private $menuContents;
+    protected $menuContents;
 
     /** @var string */
-    private $menuTemplate;
+    protected $menuTemplate;
 
     public function __construct(CommandData $commandData)
     {

--- a/src/Generators/Scaffold/RequestGenerator.php
+++ b/src/Generators/Scaffold/RequestGenerator.php
@@ -9,16 +9,16 @@ use InfyOm\Generator\Utils\FileUtil;
 class RequestGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $createFileName;
+    protected $createFileName;
 
     /** @var string */
-    private $updateFileName;
+    protected $updateFileName;
 
     public function __construct(CommandData $commandData)
     {
@@ -34,7 +34,7 @@ class RequestGenerator extends BaseGenerator
         $this->generateUpdateRequest();
     }
 
-    private function generateCreateRequest()
+    protected function generateCreateRequest()
     {
         $templateData = get_template('scaffold.request.create_request', 'laravel-generator');
 
@@ -46,7 +46,7 @@ class RequestGenerator extends BaseGenerator
         $this->commandData->commandInfo($this->createFileName);
     }
 
-    private function generateUpdateRequest()
+    protected function generateUpdateRequest()
     {
         $templateData = get_template('scaffold.request.update_request', 'laravel-generator');
 

--- a/src/Generators/Scaffold/RoutesGenerator.php
+++ b/src/Generators/Scaffold/RoutesGenerator.php
@@ -8,16 +8,16 @@ use InfyOm\Generator\Common\CommandData;
 class RoutesGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $routeContents;
+    protected $routeContents;
 
     /** @var string */
-    private $routesTemplate;
+    protected $routesTemplate;
 
     public function __construct(CommandData $commandData)
     {

--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -12,16 +12,16 @@ use InfyOm\Generator\Utils\HTMLFieldGenerator;
 class ViewGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $templateType;
+    protected $templateType;
 
     /** @var array */
-    private $htmlFields;
+    protected $htmlFields;
 
     public function __construct(CommandData $commandData)
     {
@@ -75,7 +75,7 @@ class ViewGenerator extends BaseGenerator
         $this->commandData->commandComment('Views created: ');
     }
 
-    private function generateTable()
+    protected function generateTable()
     {
         if ($this->commandData->getAddOn('datatables')) {
             $templateData = $this->generateDataTableBody();
@@ -89,14 +89,14 @@ class ViewGenerator extends BaseGenerator
         $this->commandData->commandInfo('table.blade.php created');
     }
 
-    private function generateDataTableBody()
+    protected function generateDataTableBody()
     {
         $templateData = get_template('scaffold.views.datatable_body', $this->templateType);
 
         return fill_template($this->commandData->dynamicVars, $templateData);
     }
 
-    private function generateDataTableActions()
+    protected function generateDataTableActions()
     {
         $templateData = get_template('scaffold.views.datatables_actions', $this->templateType);
 
@@ -107,7 +107,7 @@ class ViewGenerator extends BaseGenerator
         $this->commandData->commandInfo('datatables_actions.blade.php created');
     }
 
-    private function generateBladeTableBody()
+    protected function generateBladeTableBody()
     {
         $templateData = get_template('scaffold.views.blade_table_body', $this->templateType);
 
@@ -137,7 +137,7 @@ class ViewGenerator extends BaseGenerator
         return str_replace('$FIELD_BODY$', $tableBodyFields, $templateData);
     }
 
-    private function generateTableHeaderFields()
+    protected function generateTableHeaderFields()
     {
         $headerFieldTemplate = get_template('scaffold.views.table_header', $this->templateType);
 
@@ -158,7 +158,7 @@ class ViewGenerator extends BaseGenerator
         return implode(infy_nl_tab(1, 2), $headerFields);
     }
 
-    private function generateIndex()
+    protected function generateIndex()
     {
         $templateData = get_template('scaffold.views.index', $this->templateType);
 
@@ -185,7 +185,7 @@ class ViewGenerator extends BaseGenerator
         $this->commandData->commandInfo('index.blade.php created');
     }
 
-    private function generateFields()
+    protected function generateFields()
     {
         $this->htmlFields = [];
 
@@ -321,7 +321,7 @@ class ViewGenerator extends BaseGenerator
         $this->commandData->commandInfo('field.blade.php created');
     }
 
-    private function generateCreate()
+    protected function generateCreate()
     {
         $templateData = get_template('scaffold.views.create', $this->templateType);
 
@@ -331,7 +331,7 @@ class ViewGenerator extends BaseGenerator
         $this->commandData->commandInfo('create.blade.php created');
     }
 
-    private function generateUpdate()
+    protected function generateUpdate()
     {
         $templateData = get_template('scaffold.views.edit', $this->templateType);
 
@@ -341,7 +341,7 @@ class ViewGenerator extends BaseGenerator
         $this->commandData->commandInfo('edit.blade.php created');
     }
 
-    private function generateShowFields()
+    protected function generateShowFields()
     {
         $fieldTemplate = get_template('scaffold.views.show_field', $this->templateType);
 
@@ -360,7 +360,7 @@ class ViewGenerator extends BaseGenerator
         $this->commandData->commandInfo('show_fields.blade.php created');
     }
 
-    private function generateShow()
+    protected function generateShow()
     {
         $templateData = get_template('scaffold.views.show', $this->templateType);
 

--- a/src/Generators/TestTraitGenerator.php
+++ b/src/Generators/TestTraitGenerator.php
@@ -9,13 +9,13 @@ use InfyOm\Generator\Utils\GeneratorFieldsInputUtil;
 class TestTraitGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $fileName;
+    protected $fileName;
 
     public function __construct(CommandData $commandData)
     {
@@ -36,7 +36,7 @@ class TestTraitGenerator extends BaseGenerator
         $this->commandData->commandObj->info($this->fileName);
     }
 
-    private function fillTemplate($templateData)
+    protected function fillTemplate($templateData)
     {
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
 
@@ -46,7 +46,7 @@ class TestTraitGenerator extends BaseGenerator
         return $templateData;
     }
 
-    private function generateFields()
+    protected function generateFields()
     {
         $fields = [];
 

--- a/src/Generators/VueJs/APIRequestGenerator.php
+++ b/src/Generators/VueJs/APIRequestGenerator.php
@@ -9,16 +9,16 @@ use InfyOm\Generator\Utils\FileUtil;
 class APIRequestGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $createFileName;
+    protected $createFileName;
 
     /** @var string */
-    private $updateFileName;
+    protected $updateFileName;
 
     public function __construct(CommandData $commandData)
     {
@@ -34,7 +34,7 @@ class APIRequestGenerator extends BaseGenerator
         $this->generateUpdateRequest();
     }
 
-    private function generateCreateRequest()
+    protected function generateCreateRequest()
     {
         $templateData = get_template('vuejs.request.create_request', 'laravel-generator');
 
@@ -46,7 +46,7 @@ class APIRequestGenerator extends BaseGenerator
         $this->commandData->commandInfo($this->createFileName);
     }
 
-    private function generateUpdateRequest()
+    protected function generateUpdateRequest()
     {
         $templateData = get_template('vuejs.request.update_request', 'laravel-generator');
 

--- a/src/Generators/VueJs/ControllerGenerator.php
+++ b/src/Generators/VueJs/ControllerGenerator.php
@@ -9,13 +9,13 @@ use InfyOm\Generator\Utils\FileUtil;
 class ControllerGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $fileName;
+    protected $fileName;
 
     public function __construct(CommandData $commandData)
     {
@@ -66,7 +66,7 @@ class ControllerGenerator extends BaseGenerator
         $this->commandData->commandInfo($this->fileName);
     }
 
-    private function fillDocs($templateData)
+    protected function fillDocs($templateData)
     {
         $methods = ['controller', 'index', 'store', 'show', 'update', 'destroy'];
 

--- a/src/Generators/VueJs/ModelJsConfigGenerator.php
+++ b/src/Generators/VueJs/ModelJsConfigGenerator.php
@@ -9,19 +9,19 @@ use InfyOm\Generator\Utils\FileUtil;
 class ModelJsConfigGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $fileName;
+    protected $fileName;
 
     /** @var string */
-    private $templateType;
+    protected $templateType;
 
     /** @var array */
-    private $htmlFields;
+    protected $htmlFields;
 
     public function __construct(CommandData $commandData)
     {
@@ -40,7 +40,7 @@ class ModelJsConfigGenerator extends BaseGenerator
         $this->commandData->commandComment('ModelJsConfig created.');
     }
 
-    private function generateModelJs()
+    protected function generateModelJs()
     {
         $templateData = get_template('vuejs.js.model-config', 'laravel-generator');
         $fieldsRow = '';

--- a/src/Generators/VueJs/RoutesGenerator.php
+++ b/src/Generators/VueJs/RoutesGenerator.php
@@ -9,25 +9,25 @@ use InfyOm\Generator\Generators\BaseGenerator;
 class RoutesGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $pathApi;
+    protected $pathApi;
 
     /** @var string */
-    private $routeContents;
+    protected $routeContents;
 
     /** @var string */
-    private $apiRouteContents;
+    protected $apiRouteContents;
 
     /** @var string */
-    private $routesTemplate;
+    protected $routesTemplate;
 
     /** @var string */
-    private $apiRoutesTemplate;
+    protected $apiRoutesTemplate;
 
     public function __construct(CommandData $commandData)
     {

--- a/src/Generators/VueJs/TestGenerator.php
+++ b/src/Generators/VueJs/TestGenerator.php
@@ -9,13 +9,13 @@ use InfyOm\Generator\Utils\FileUtil;
 class TestGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $fileName;
+    protected $fileName;
 
     public function __construct(CommandData $commandData)
     {

--- a/src/Generators/VueJs/ViewGenerator.php
+++ b/src/Generators/VueJs/ViewGenerator.php
@@ -10,16 +10,16 @@ use InfyOm\Generator\Utils\GeneratorFieldsInputUtil;
 class ViewGenerator extends BaseGenerator
 {
     /** @var CommandData */
-    private $commandData;
+    protected $commandData;
 
     /** @var string */
-    private $path;
+    protected $path;
 
     /** @var string */
-    private $templateType;
+    protected $templateType;
 
     /** @var array */
-    private $htmlFields;
+    protected $htmlFields;
 
     public function __construct(CommandData $commandData)
     {
@@ -44,7 +44,7 @@ class ViewGenerator extends BaseGenerator
         $this->commandData->commandComment('Views created: ');
     }
 
-    private function generateTable()
+    protected function generateTable()
     {
         $templateData = $this->generateBladeTableBody();
 
@@ -53,7 +53,7 @@ class ViewGenerator extends BaseGenerator
         $this->commandData->commandInfo('table.blade.php created');
     }
 
-    private function generateBladeTableBody()
+    protected function generateBladeTableBody()
     {
         $templateData = get_template('vuejs.views.blade_table_body', $this->templateType);
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
@@ -61,7 +61,7 @@ class ViewGenerator extends BaseGenerator
         return $templateData;
     }
 
-    private function generateIndex()
+    protected function generateIndex()
     {
         $templateData = get_template('vuejs.views.index', $this->templateType);
 
@@ -88,7 +88,7 @@ class ViewGenerator extends BaseGenerator
         $this->commandData->commandInfo('index.blade.php created');
     }
 
-    private function generateFields()
+    protected function generateFields()
     {
         $this->htmlFields = [];
         foreach ($this->commandData->fields as $field) {
@@ -208,7 +208,7 @@ class ViewGenerator extends BaseGenerator
         $this->commandData->commandInfo('fields.blade.php created');
     }
 
-    private function generateForm()
+    protected function generateForm()
     {
         $templateData = get_template('vuejs.views.form', $this->templateType);
 
@@ -218,7 +218,7 @@ class ViewGenerator extends BaseGenerator
         $this->commandData->commandInfo('form.blade.php created');
     }
 
-    private function generateShow()
+    protected function generateShow()
     {
         $templateData = get_template('vuejs.views.show', $this->templateType);
 
@@ -228,7 +228,7 @@ class ViewGenerator extends BaseGenerator
         $this->commandData->commandInfo('show.blade.php created');
     }
 
-    private function generateDelete()
+    protected function generateDelete()
     {
         $templateData = get_template('vuejs.views.delete', $this->templateType);
 

--- a/src/Utils/GeneratorFieldsInputUtil.php
+++ b/src/Utils/GeneratorFieldsInputUtil.php
@@ -2,6 +2,7 @@
 
 namespace InfyOm\Generator\Utils;
 
+use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\GeneratorField;
 
 class GeneratorFieldsInputUtil
@@ -22,6 +23,7 @@ class GeneratorFieldsInputUtil
      * @param $validations
      *
      * @return GeneratorField
+     * @throws \ReflectionException
      */
     public static function processFieldInput($fieldInput, $validations)
     {
@@ -41,7 +43,8 @@ class GeneratorFieldsInputUtil
 
         $fieldInputsArr = explode(' ', $fieldInput);
 
-        $field = new GeneratorField();
+        /** @var GeneratorField $field */
+        $field = ClassInjectionConfig::createClassByConfigPath('Common.generator_field');
         $field->name = $fieldInputsArr[0];
         $field->parseDBType($fieldInputsArr[1]);
 

--- a/src/Utils/GeneratorForeignKey.php
+++ b/src/Utils/GeneratorForeignKey.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace InfyOm\Generator\Utils;
+
+
+class GeneratorForeignKey
+{
+    /** @var string */
+    public $name;
+    public $localField;
+    public $foreignField;
+    public $foreignTable;
+    public $onUpdate;
+    public $onDelete;
+}

--- a/src/Utils/GeneratorTable.php
+++ b/src/Utils/GeneratorTable.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @copyright Copyright (c) 2018. Wubbleyou Ltd
+ */
+
+namespace InfyOm\Generator\Utils;
+
+
+class GeneratorTable
+{
+    /** @var string */
+    public $primaryKey;
+
+    /** @var GeneratorForeignKey[] */
+    public $foreignKeys;
+}

--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -7,26 +7,6 @@ use InfyOm\Generator\Common\ClassInjectionConfig;
 use InfyOm\Generator\Common\GeneratorField;
 use InfyOm\Generator\Common\GeneratorFieldRelation;
 
-class GeneratorForeignKey
-{
-    /** @var string */
-    public $name;
-    public $localField;
-    public $foreignField;
-    public $foreignTable;
-    public $onUpdate;
-    public $onDelete;
-}
-
-class GeneratorTable
-{
-    /** @var string */
-    public $primaryKey;
-
-    /** @var GeneratorForeignKey[] */
-    public $foreignKeys;
-}
-
 class TableFieldsGenerator
 {
     /** @var string */
@@ -40,10 +20,10 @@ class TableFieldsGenerator
     public $timestamps;
 
     /** @var \Doctrine\DBAL\Schema\AbstractSchemaManager */
-    private $schemaManager;
+    protected $schemaManager;
 
     /** @var \Doctrine\DBAL\Schema\Column[] */
-    private $columns;
+    protected $columns;
 
     /** @var GeneratorField[] */
     public $fields;
@@ -176,7 +156,7 @@ class TableFieldsGenerator
      * @return GeneratorField
      * @throws \ReflectionException
      */
-    private function generateIntFieldInput($column, $dbType)
+    protected function generateIntFieldInput($column, $dbType)
     {
         /** @var GeneratorField $field */
         $field = ClassInjectionConfig::createClassByConfigPath('Common.generator_field');
@@ -204,7 +184,7 @@ class TableFieldsGenerator
      *
      * @return GeneratorField
      */
-    private function checkForPrimary(GeneratorField $field)
+    protected function checkForPrimary(GeneratorField $field)
     {
         if ($field->name == $this->primaryKey) {
             $field->isPrimary = true;
@@ -227,7 +207,7 @@ class TableFieldsGenerator
      * @return GeneratorField
      * @throws \ReflectionException
      */
-    private function generateField($column, $dbType, $htmlType)
+    protected function generateField($column, $dbType, $htmlType)
     {
         /** @var GeneratorField $field */
         $field = ClassInjectionConfig::createClassByConfigPath('Common.generator_field');
@@ -247,7 +227,7 @@ class TableFieldsGenerator
      * @return GeneratorField
      * @throws \ReflectionException
      */
-    private function generateNumberInput($column, $dbType)
+    protected function generateNumberInput($column, $dbType)
     {
         /** @var GeneratorField $field */
         $field = ClassInjectionConfig::createClassByConfigPath('Common.generator_field');
@@ -313,7 +293,7 @@ class TableFieldsGenerator
      * @param GeneratorTable[] $tables
      * @throws \Exception
      */
-    private function checkForRelations($tables)
+    protected function checkForRelations($tables)
     {
 
         /** @var GeneratorFieldRelation $generatorFieldRelationClass */
@@ -385,7 +365,7 @@ class TableFieldsGenerator
      * @return bool|GeneratorFieldRelation
      * @throws \Exception
      */
-    private function isManyToMany($tables, $tableName, $modelTable, $modelTableName)
+    protected function isManyToMany($tables, $tableName, $modelTable, $modelTableName)
     {
         // get table details
         $table = $tables[$tableName];
@@ -453,7 +433,7 @@ class TableFieldsGenerator
      *
      * @return bool
      */
-    private function isOneToOne($primaryKey, $foreignKey, $modelTablePrimary)
+    protected function isOneToOne($primaryKey, $foreignKey, $modelTablePrimary)
     {
         if ($foreignKey->foreignField == $modelTablePrimary) {
             if ($foreignKey->localField == $primaryKey) {
@@ -475,7 +455,7 @@ class TableFieldsGenerator
      *
      * @return bool
      */
-    private function isOneToMany($primaryKey, $foreignKey, $modelTablePrimary)
+    protected function isOneToMany($primaryKey, $foreignKey, $modelTablePrimary)
     {
         if ($foreignKey->foreignField == $modelTablePrimary) {
             if ($foreignKey->localField != $primaryKey) {
@@ -496,7 +476,7 @@ class TableFieldsGenerator
      * @return array
      * @throws \Exception
      */
-    private function detectManyToOne($tables, $modelTable)
+    protected function detectManyToOne($tables, $modelTable)
     {
         /** @var GeneratorFieldRelation $generatorFieldRelationClass */
         $generatorFieldRelationClass = ClassInjectionConfig::getClassByConfigPath('Common.generator_field_relation');


### PR DESCRIPTION
These changes are aimed to resolve the following problems:

- The library is not easily configurable or extend-able
- Because the library is not easily extend-able, we must therefore maintain our own version outside of composer, making it difficult to keep on top of updates

To fix this, I've introduced a simple method to replace all important class creation + static calls with a class called `ClassInjectionConfig`.  This class maintains a list of all default classes which are then easily override-able via the `laravel_generator.php` config file.  This allows us to simply create a class in our own code base, and override the config to point the existing library to the injected class.

I've also changed all `private` methods & variables to `protected` in the configurable classes, to ensure we're able to easily extend them if we choose to override them.

A valid use case would be if we wanted to extend the model validation generation to fit our naming conventions (e.g. validating fields named `email` with an email validator).  Currently, we cannot do this without forking the code base.  This PR would allow us to simply extend the ModelGenerator class, add our code and then configure the `laravel_generator.php` to use our extended generator.