### PR TITLE
#380 Take swagger description from comments of DB Column

### DIFF
--- a/src/Common/GeneratorField.php
+++ b/src/Common/GeneratorField.php
@@ -12,6 +12,7 @@ class GeneratorField
     public $htmlInput;
     public $htmlType;
     public $fieldType;
+    public $description;
 
     /** @var array */
     public $htmlValues;

--- a/src/Generators/SwaggerGenerator.php
+++ b/src/Generators/SwaggerGenerator.php
@@ -87,7 +87,7 @@ class SwaggerGenerator
                 //                if (isset($field['description'])) {
                 //                    $fieldType['description'] = $field['description'];
                 //                } else {
-                $fieldType['description'] = '';
+                $fieldType['description'] = (!empty($field->description)) ? $field->description : '';
                 //                }
 
                 $fieldTypes[] = $fieldType;

--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -148,6 +148,7 @@ class TableFieldsGenerator
                 $field->inIndex = false;
             }
             $field->isNotNull = (bool) $column->getNotNull();
+            $field->description = $column->getComment(); // get comments from table
 
             $this->fields[] = $field;
         }


### PR DESCRIPTION
#380 

While creating scaffold using `--fromTable`, descriptions of swagger doc should be taken from database column comments, if it is there.