### PR TITLE
getQualifiedForeignKey -> getQualifiedForeignKeyName

### DIFF
--- a/src/Common/BaseRepository.php
+++ b/src/Common/BaseRepository.php
@@ -60,7 +60,7 @@ abstract class BaseRepository extends \Prettus\Repository\Eloquent\BaseRepositor
                         $model->$key()->sync(array_values($new_values));
                         break;
                     case 'Illuminate\Database\Eloquent\Relations\BelongsTo':
-                        $model_key = $model->$key()->getQualifiedForeignKey();
+                        $model_key = $model->$key()->getQualifiedForeignKeyName();
                         $new_value = array_get($attributes, $key, null);
                         $new_value = $new_value == '' ? null : $new_value;
                         $model->$model_key = $new_value;


### PR DESCRIPTION
In Laravel 5.8 the `getForeignKey` and `getQualifiedForeignKey` methods of the `BelongsTo` relationship have been renamed to `getForeignKeyName` and `getQualifiedForeignKeyName` respectively.