### PR TITLE
Column `id` should not be required into rules while creating module

### DIFF
--- a/config/laravel_generator.php
+++ b/config/laravel_generator.php
@@ -121,6 +121,8 @@ return [
         'softDelete' => true,
 
         'tables_searchable_default' => false,
+
+        'excluded_fields' => ['id'], // Array of columns that doesn't required while creating module
     ],
 
     /*


### PR DESCRIPTION
Steps to Reproduce ( **Issue will reproduce only when PR changes are not applied** ) :
1. Create module direct from table by using `php artisan infyom:scaffold ModelName --fromTable --tableName=tablename`
2. Enter your data to field and submit

Error messages display that `id is required field`.

Solution : 

id should not be added into `Model:rules` as required field. 

Add `excluded_fields` into config => options and defined `id` to there, so it is ignored while generating rules for module.
