### PR TITLE
Create CRUD with custom table name using generator builder

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -136,11 +136,12 @@ class BaseCommand extends Command
         }
 
         if ($runMigration) {
-            $fromFile = ($this->commandData->getOption('fieldsFile') or $this->commandData->getOption('jsonFromGUI')) ? true : false;
             if ($this->commandData->config->forceMigrate) {
                 $this->call('migrate');
             } elseif (!$this->commandData->getOption('fromTable') and !$this->isSkip('migration')) {
-                if (!$fromFile && $this->confirm("\nDo you want to migrate database? [y|N]", false)) {
+                if ($this->commandData->getOption('jsonFromGUI')) {
+                    $this->call('migrate');
+                } elseif ($this->confirm("\nDo you want to migrate database? [y|N]", false)) {
                     $this->call('migrate');
                 }
             }

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -136,10 +136,11 @@ class BaseCommand extends Command
         }
 
         if ($runMigration) {
+            $fromFile = ($this->commandData->getOption('fieldsFile') or $this->commandData->getOption('jsonFromGUI')) ? true : false;
             if ($this->commandData->config->forceMigrate) {
                 $this->call('migrate');
             } elseif (!$this->commandData->getOption('fromTable') and !$this->isSkip('migration')) {
-                if ($this->confirm("\nDo you want to migrate database? [y|N]", false)) {
+                if (!$fromFile && $this->confirm("\nDo you want to migrate database? [y|N]", false)) {
                     $this->call('migrate');
                 }
             }

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -139,9 +139,7 @@ class BaseCommand extends Command
             if ($this->commandData->config->forceMigrate) {
                 $this->call('migrate');
             } elseif (!$this->commandData->getOption('fromTable') and !$this->isSkip('migration')) {
-                if ($this->commandData->getOption('jsonFromGUI')) {
-                    $this->call('migrate');
-                } elseif ($this->confirm("\nDo you want to migrate database? [y|N]", false)) {
+                if ($this->confirm("\nDo you want to migrate database? [y|N]", false)) {
                     $this->call('migrate');
                 }
             }

--- a/src/Common/CommandData.php
+++ b/src/Common/CommandData.php
@@ -237,8 +237,8 @@ class CommandData
                 }
 
                 // Manage migrate option
-                if (isset($jsonData['migrate'])) {
-                    $this->config->forceMigrate = $jsonData['migrate'];
+                if (isset($jsonData['migrate']) && $jsonData['migrate'] == false) {
+                    $this->config->options['skip'][] = 'migration';
                 }
 
                 foreach ($jsonData['fields'] as $field) {

--- a/src/Common/CommandData.php
+++ b/src/Common/CommandData.php
@@ -236,11 +236,6 @@ class CommandData
                     $this->addDynamicVariable('$TABLE_NAME_PLURAL$', Str::title($tableName));
                 }
 
-                // override config add ons from jsonFromGUI
-                foreach ($jsonData['addOns'] as $addOn => $value) {
-                    $this->config->addOns[$addOn] = $value;
-                }
-
                 foreach ($jsonData['fields'] as $field) {
                     if (isset($field['type']) && $field['relation']) {
                         $this->relations[] = GeneratorFieldRelation::parseRelation($field['relation']);

--- a/src/Common/CommandData.php
+++ b/src/Common/CommandData.php
@@ -228,11 +228,17 @@ class CommandData
                 $fileContents = $this->getOption('jsonFromGUI');
                 $jsonData = json_decode($fileContents, true);
 
+                // Manage custom table name option
                 if (isset($jsonData['tableName']) and !empty($jsonData['tableName'])) {
                     $tableName = $jsonData['tableName'];
                     $this->config->tableName = $tableName;
                     $this->addDynamicVariable('$TABLE_NAME$', $tableName);
                     $this->addDynamicVariable('$TABLE_NAME_PLURAL$', Str::title($tableName));
+                }
+
+                // Manage datatables option
+                if (isset($jsonData['options']['datatables']) && $jsonData['options']['datatables'] == true) {
+                    $this->config->setAddOn('datatables', $jsonData['options']['datatables']);
                 }
 
                 foreach ($jsonData['fields'] as $field) {

--- a/src/Common/CommandData.php
+++ b/src/Common/CommandData.php
@@ -229,11 +229,16 @@ class CommandData
                 $jsonData = json_decode($fileContents, true);
 
                 // Manage custom table name option
-                if (isset($jsonData['tableName']) and !empty($jsonData['tableName'])) {
+                if (isset($jsonData['tableName'])) {
                     $tableName = $jsonData['tableName'];
                     $this->config->tableName = $tableName;
                     $this->addDynamicVariable('$TABLE_NAME$', $tableName);
                     $this->addDynamicVariable('$TABLE_NAME_PLURAL$', Str::title($tableName));
+                }
+
+                // Manage migrate option
+                if (isset($jsonData['migrate'])) {
+                    $this->config->forceMigrate = $jsonData['migrate'];
                 }
 
                 foreach ($jsonData['fields'] as $field) {

--- a/src/Common/CommandData.php
+++ b/src/Common/CommandData.php
@@ -233,7 +233,7 @@ class CommandData
                     $tableName = $jsonData['tableName'];
                     $this->config->tableName = $tableName;
                     $this->addDynamicVariable('$TABLE_NAME$', $tableName);
-                    $this->addDynamicVariable('$TABLE_NAME_TITLE$', Str::title($tableName));
+                    $this->addDynamicVariable('$TABLE_NAME_TITLE$', Str::studly($tableName));
                 }
 
                 // Manage migrate option

--- a/src/Common/CommandData.php
+++ b/src/Common/CommandData.php
@@ -236,9 +236,9 @@ class CommandData
                     $this->addDynamicVariable('$TABLE_NAME_PLURAL$', Str::title($tableName));
                 }
 
-                // Manage datatables option
-                if (isset($jsonData['options']['datatables']) && $jsonData['options']['datatables'] == true) {
-                    $this->config->setAddOn('datatables', $jsonData['options']['datatables']);
+                // override config add ons from jsonFromGUI
+                foreach ($jsonData['addOns'] as $addOn => $value) {
+                    $this->config->addOns[$addOn] = $value;
                 }
 
                 foreach ($jsonData['fields'] as $field) {

--- a/src/Common/CommandData.php
+++ b/src/Common/CommandData.php
@@ -4,6 +4,7 @@ namespace InfyOm\Generator\Common;
 
 use Exception;
 use Illuminate\Console\Command;
+use Illuminate\Support\Str;
 use InfyOm\Generator\Utils\GeneratorFieldsInputUtil;
 use InfyOm\Generator\Utils\TableFieldsGenerator;
 
@@ -226,6 +227,14 @@ class CommandData
             } else {
                 $fileContents = $this->getOption('jsonFromGUI');
                 $jsonData = json_decode($fileContents, true);
+
+                if (isset($jsonData['tableName']) and !empty($jsonData['tableName'])) {
+                    $tableName = $jsonData['tableName'];
+                    $this->config->tableName = $tableName;
+                    $this->addDynamicVariable('$TABLE_NAME$', $tableName);
+                    $this->addDynamicVariable('$TABLE_NAME_PLURAL$', Str::title($tableName));
+                }
+
                 foreach ($jsonData['fields'] as $field) {
                     if (isset($field['type']) && $field['relation']) {
                         $this->relations[] = GeneratorFieldRelation::parseRelation($field['relation']);

--- a/src/Common/CommandData.php
+++ b/src/Common/CommandData.php
@@ -233,7 +233,7 @@ class CommandData
                     $tableName = $jsonData['tableName'];
                     $this->config->tableName = $tableName;
                     $this->addDynamicVariable('$TABLE_NAME$', $tableName);
-                    $this->addDynamicVariable('$TABLE_NAME_PLURAL$', Str::title($tableName));
+                    $this->addDynamicVariable('$TABLE_NAME_TITLE$', Str::title($tableName));
                 }
 
                 // Manage migrate option

--- a/src/Common/GeneratorConfig.php
+++ b/src/Common/GeneratorConfig.php
@@ -232,7 +232,7 @@ class GeneratorConfig
         $commandData->addDynamicVariable('$NAMESPACE_TESTS$', $this->nsTests);
 
         $commandData->addDynamicVariable('$TABLE_NAME$', $this->tableName);
-        $commandData->addDynamicVariable('$TABLE_NAME_PLURAL$', $this->mCamelPlural);
+        $commandData->addDynamicVariable('$TABLE_NAME_PLURAL$', $this->mPlural);
         $commandData->addDynamicVariable('$PRIMARY_KEY_NAME$', $this->primaryName);
 
         $commandData->addDynamicVariable('$MODEL_NAME$', $this->mName);

--- a/src/Common/GeneratorConfig.php
+++ b/src/Common/GeneratorConfig.php
@@ -232,7 +232,7 @@ class GeneratorConfig
         $commandData->addDynamicVariable('$NAMESPACE_TESTS$', $this->nsTests);
 
         $commandData->addDynamicVariable('$TABLE_NAME$', $this->tableName);
-        $commandData->addDynamicVariable('$TABLE_NAME_TITLE$', Str::title($this->tableName));
+        $commandData->addDynamicVariable('$TABLE_NAME_TITLE$', Str::studly($this->tableName));
         $commandData->addDynamicVariable('$PRIMARY_KEY_NAME$', $this->primaryName);
 
         $commandData->addDynamicVariable('$MODEL_NAME$', $this->mName);

--- a/src/Common/GeneratorConfig.php
+++ b/src/Common/GeneratorConfig.php
@@ -476,6 +476,11 @@ class GeneratorConfig
         $this->options[$option] = $value;
     }
 
+    public function setAddOn($addOn, $value)
+    {
+        $this->addOns[$addOn] = $value;
+    }
+
     public function prepareAddOns()
     {
         $this->addOns['swagger'] = config('infyom.laravel_generator.add_on.swagger', false);

--- a/src/Common/GeneratorConfig.php
+++ b/src/Common/GeneratorConfig.php
@@ -232,6 +232,7 @@ class GeneratorConfig
         $commandData->addDynamicVariable('$NAMESPACE_TESTS$', $this->nsTests);
 
         $commandData->addDynamicVariable('$TABLE_NAME$', $this->tableName);
+        $commandData->addDynamicVariable('$TABLE_NAME_PLURAL$', $this->mCamelPlural);
         $commandData->addDynamicVariable('$PRIMARY_KEY_NAME$', $this->primaryName);
 
         $commandData->addDynamicVariable('$MODEL_NAME$', $this->mName);

--- a/src/Common/GeneratorConfig.php
+++ b/src/Common/GeneratorConfig.php
@@ -232,7 +232,7 @@ class GeneratorConfig
         $commandData->addDynamicVariable('$NAMESPACE_TESTS$', $this->nsTests);
 
         $commandData->addDynamicVariable('$TABLE_NAME$', $this->tableName);
-        $commandData->addDynamicVariable('$TABLE_NAME_PLURAL$', $this->mPlural);
+        $commandData->addDynamicVariable('$TABLE_NAME_TITLE$', Str::title($this->tableName));
         $commandData->addDynamicVariable('$PRIMARY_KEY_NAME$', $this->primaryName);
 
         $commandData->addDynamicVariable('$MODEL_NAME$', $this->mName);

--- a/src/Common/GeneratorConfig.php
+++ b/src/Common/GeneratorConfig.php
@@ -476,11 +476,6 @@ class GeneratorConfig
         $this->options[$option] = $value;
     }
 
-    public function setAddOn($addOn, $value)
-    {
-        $this->addOns[$addOn] = $value;
-    }
-
     public function prepareAddOns()
     {
         $this->addOns['swagger'] = config('infyom.laravel_generator.add_on.swagger', false);

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -32,7 +32,7 @@ class MigrationGenerator extends BaseGenerator
 
         $tableName = $this->commandData->dynamicVars['$TABLE_NAME$'];
 
-        $fileName = date('Y_m_d_His').'_'.'create_'.$tableName.'_table.php';
+        $fileName = date('Y_m_d_His').'_'.'create_'.strtolower($tableName).'_table.php';
 
         FileUtil::createFile($this->path, $fileName, $templateData);
 

--- a/templates/migration.stub
+++ b/templates/migration.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class Create$TABLE_NAME_PLURAL$Table extends Migration
+class Create$TABLE_NAME_TITLE$Table extends Migration
 {
 
     /**

--- a/templates/migration.stub
+++ b/templates/migration.stub
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class Create$MODEL_NAME_PLURAL$Table extends Migration
+class Create$TABLE_NAME_PLURAL$Table extends Migration
 {
 
     /**


### PR DESCRIPTION
Issues Fixed : 
while creating crud using generator builder, when we enter custom table name generator  will take table name from model name. 

Also option `migrate` is not working
