### PR TITLE
Option `forceMigrate` added to run migration

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -136,7 +136,7 @@ class BaseCommand extends Command
         }
 
         if ($runMigration) {
-            if ($this->commandData->config->forceMigrate) {
+            if ($this->commandData->getOption('forceMigrate')) {
                 $this->call('migrate');
             } elseif (!$this->commandData->getOption('fromTable') and !$this->isSkip('migration')) {
                 if ($this->commandData->getOption('jsonFromGUI')) {
@@ -240,6 +240,7 @@ class BaseCommand extends Command
             ['datatables', null, InputOption::VALUE_REQUIRED, 'Override datatables settings'],
             ['views', null, InputOption::VALUE_REQUIRED, 'Specify only the views you want generated: index,create,edit,show'],
             ['relations', null, InputOption::VALUE_NONE, 'Specify if you want to pass relationships for fields'],
+            ['forceMigrate', null, InputOption::VALUE_NONE, 'Specify if you want to run migration or not'],
         ];
     }
 

--- a/src/Common/GeneratorConfig.php
+++ b/src/Common/GeneratorConfig.php
@@ -57,8 +57,6 @@ class GeneratorConfig
     public $mHuman;
     public $mHumanPlural;
 
-    public $forceMigrate;
-
     /* Generator Options */
     public $options;
 
@@ -81,6 +79,7 @@ class GeneratorConfig
         'views',
         'relations',
         'plural',
+        'forceMigrate',
     ];
 
     public $tableName;


### PR DESCRIPTION
If you want to run migration by skipping confirmation message ( Y | N), just pass option `--forceMigrate` with any command of infyom generator