### PR TITLE
Allow generation inside module

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -253,6 +253,7 @@ class BaseCommand extends Command
             ['relations', null, InputOption::VALUE_NONE, 'Specify if you want to pass relationships for fields'],
             ['softDelete', null, InputOption::VALUE_NONE, 'Soft Delete Option'],
             ['forceMigrate', null, InputOption::VALUE_NONE, 'Specify if you want to run migration or not'],
+            ['moduleName', null, InputOption::VALUE_REQUIRED, 'Generate files to this module & namespace (eg. Admin)'],
         ];
     }
 

--- a/src/Commands/RollbackGeneratorCommand.php
+++ b/src/Commands/RollbackGeneratorCommand.php
@@ -77,10 +77,11 @@ class RollbackGeneratorCommand extends Command
             $this->error('invalid rollback type');
         }
 
+
         $this->commandData = new CommandData($this, $this->argument('type'));
         $this->commandData->config->mName = $this->commandData->modelName = $this->argument('model');
 
-        $this->commandData->config->init($this->commandData, ['tableName', 'prefix', 'plural']);
+        $this->commandData->config->init($this->commandData, ['tableName', 'prefix', 'plural', 'moduleName']);
 
         $migrationGenerator = new MigrationGenerator($this->commandData);
         $migrationGenerator->rollback();
@@ -155,6 +156,7 @@ class RollbackGeneratorCommand extends Command
             ['tableName', null, InputOption::VALUE_REQUIRED, 'Table Name'],
             ['prefix', null, InputOption::VALUE_REQUIRED, 'Prefix for all files'],
             ['plural', null, InputOption::VALUE_REQUIRED, 'Plural Model name'],
+            ['moduleName', null, InputOption::VALUE_REQUIRED, 'Generate files to this module & namespace (eg. Admin)'],
         ];
     }
 

--- a/src/Commands/RollbackGeneratorCommand.php
+++ b/src/Commands/RollbackGeneratorCommand.php
@@ -77,7 +77,6 @@ class RollbackGeneratorCommand extends Command
             $this->error('invalid rollback type');
         }
 
-
         $this->commandData = new CommandData($this, $this->argument('type'));
         $this->commandData->config->mName = $this->commandData->modelName = $this->argument('model');
 

--- a/src/Common/GeneratorConfig.php
+++ b/src/Common/GeneratorConfig.php
@@ -353,6 +353,54 @@ class GeneratorConfig
                 $this->addOns['datatables'] = false;
             }
         }
+        if (!empty($this->options['moduleName'])) {
+            if (!file_exists(config_path('modules.php'))) {
+                $commandData->commandError('Can\'t use modules since config doesn\'t exist in '.config_path('modules.php').'.');
+                exit;
+            }
+            // change folder locations
+            $this->modules_path = config('modules.paths.modules', base_path('Modules')).'/'.$this->options['moduleName'];
+            $config_paths = config('infyom.laravel_generator.path');
+            $new_config_paths = [];
+            foreach($config_paths as $key => $path) {
+                if (preg_match('/migrations/', $path))
+                    $path = str_replace('migrations', 'Migrations', $path);
+                if (strpos($path, app_path()) === 0) {
+                    $new_config_paths[$key] = str_replace(app_path(), $this->modules_path, $path);
+                } else {
+                    $new_config_paths[$key] = str_replace(base_path(), $this->modules_path, $path);
+                }
+                $new_config_paths[$key][strlen($this->modules_path)+1] = strtoupper($new_config_paths[$key][strlen($this->modules_path)+1]);
+            }
+            config(['infyom.laravel_generator.path' => $new_config_paths]);
+
+            // change namespace
+            $this->module_namespace = config('modules.namespace', 'Modules').'\\'.$this->options['moduleName'].'\\';
+            $config_namespaces = config('infyom.laravel_generator.namespace');
+            $new_config_namespaces = [];
+            foreach($config_namespaces as $key => $namespace)
+            {
+                if (strpos($namespace, 'App\\') === 0)
+                    $namespace = str_replace('App\\', '', $namespace);
+                $new_config_namespaces[$key] = $this->module_namespace.$namespace;
+            }
+            config(['infyom.laravel_generator.namespace' => $new_config_namespaces]);
+
+            // change prefix
+            $viewPrefix = $this->prefixes['view'];
+            config(['infyom.laravel_generator.prefixes.view' => strtolower($this->options['moduleName']).'::']);
+            $this->prefixes['view'] = config('infyom.laravel_generator.prefixes.view');
+            if ($this->getOption('plural')) {
+                $this->mPlural = $this->getOption('plural');
+            } else {
+                $this->mPlural = Str::plural($this->mName);
+            }
+            $this->mSnakePlural = Str::snake($this->mPlural);
+            $this->pathViews = config(
+                'infyom.laravel_generator.path.views',
+                base_path('resources/views/')
+            ).$viewPrefix.$this->mSnakePlural.'/';
+        }
     }
 
     public function preparePrefixes()


### PR DESCRIPTION
This enables Infyom Laravel Generator to be used with https://github.com/nWidart/laravel-modules.

I added another option `--moduleName` which when specified, changes the config locations and namespace point to the given module.

Should fix: #371 