### PR TITLE
Fixed duplicate creation of relations #709

### DIFF
--- a/src/Common/GeneratorFieldRelation.php
+++ b/src/Common/GeneratorFieldRelation.php
@@ -27,10 +27,11 @@ class GeneratorFieldRelation
         return $relation;
     }
 
-    public function getRelationFunctionText()
+    public function getRelationFunctionText($relationText = null)
     {
         $singularRelation = (!empty($this->relationName)) ? $this->relationName : Str::camel($this->inputs[0]);
         $pluralRelation = (!empty($this->relationName)) ? $this->relationName : Str::camel(Str::plural($this->inputs[0]));
+        $relationText = (!empty($relationText)) ? $relationText : null;
 
         switch ($this->type) {
             case '1t1':
@@ -41,8 +42,8 @@ class GeneratorFieldRelation
             case '1tm':
                 if (!empty($this->relationName)) {
                     $pluralRelation = $this->relationName;
-                } elseif (isset($this->inputs[1])) {
-                    $pluralRelation = Str::camel(Str::plural(str_replace('_id', '', strtolower($this->inputs[1]))));
+                } elseif (isset($relationText)) {
+                    $pluralRelation = Str::camel(Str::plural(str_replace('_id', '', strtolower($relationText))));
                 }
                 $functionName = $pluralRelation;
                 $relation = 'hasMany';
@@ -51,8 +52,8 @@ class GeneratorFieldRelation
             case 'mt1':
                 if (!empty($this->relationName)) {
                     $singularRelation = $this->relationName;
-                } elseif (isset($this->inputs[1])) {
-                    $singularRelation = Str::camel(str_replace('_id', '', strtolower($this->inputs[1])));
+                } elseif (isset($relationText)) {
+                    $singularRelation = Str::camel(str_replace('_id', '', strtolower($relationText)));
                 }
                 $functionName = $singularRelation;
                 $relation = 'belongsTo';

--- a/src/Common/GeneratorFieldRelation.php
+++ b/src/Common/GeneratorFieldRelation.php
@@ -29,9 +29,8 @@ class GeneratorFieldRelation
 
     public function getRelationFunctionText($relationText = null)
     {
-        $singularRelation = (!empty($this->relationName)) ? $this->relationName : Str::camel($this->inputs[0]);
-        $pluralRelation = (!empty($this->relationName)) ? $this->relationName : Str::camel(Str::plural($this->inputs[0]));
-        $relationText = (!empty($relationText)) ? $relationText : null;
+        $singularRelation = (!empty($this->relationName)) ? $this->relationName : Str::camel($relationText);
+        $pluralRelation = (!empty($this->relationName)) ? $this->relationName : Str::camel(Str::plural($relationText));
 
         switch ($this->type) {
             case '1t1':
@@ -40,11 +39,6 @@ class GeneratorFieldRelation
                 $relationClass = 'HasOne';
                 break;
             case '1tm':
-                if (!empty($this->relationName)) {
-                    $pluralRelation = $this->relationName;
-                } elseif (isset($relationText)) {
-                    $pluralRelation = Str::camel(Str::plural(str_replace('_id', '', strtolower($relationText))));
-                }
                 $functionName = $pluralRelation;
                 $relation = 'hasMany';
                 $relationClass = 'HasMany';
@@ -52,8 +46,8 @@ class GeneratorFieldRelation
             case 'mt1':
                 if (!empty($this->relationName)) {
                     $singularRelation = $this->relationName;
-                } elseif (isset($relationText)) {
-                    $singularRelation = Str::camel(str_replace('_id', '', strtolower($relationText)));
+                } elseif (isset($this->inputs[1])) {
+                    $singularRelation = Str::camel(str_replace('_id', '', strtolower($this->inputs[1])));
                 }
                 $functionName = $singularRelation;
                 $relation = 'belongsTo';

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -121,25 +121,33 @@ class ModelGenerator extends BaseGenerator
     private function fillDocs($templateData)
     {
         if ($this->commandData->getAddOn('swagger')) {
-            $templateData = $this->generateSwagger($templateData);
-        } else {
-            $docsTemplate = get_template('docs.model', 'laravel-generator');
-            $docsTemplate = fill_template($this->commandData->dynamicVars, $docsTemplate);
-
-            $fillables = '';
-            foreach ($this->commandData->relations as $relation) {
-                $fillables .= ' * @property '.$this->getPHPDocType($relation->type, $relation).PHP_EOL;
-            }
-            foreach ($this->commandData->fields as $field) {
-                if ($field->isFillable) {
-                    $fillables .= ' * @property '.$this->getPHPDocType($field->fieldType).' '.$field->name.PHP_EOL;
-                }
-            }
-            $docsTemplate = str_replace('$GENERATE_DATE$', date('F j, Y, g:i a T'), $docsTemplate);
-            $docsTemplate = str_replace('$PHPDOC$', $fillables, $docsTemplate);
-
-            $templateData = str_replace('$DOCS$', $docsTemplate, $templateData);
+            return $this->generateSwagger($templateData);
         }
+
+        $docsTemplate = get_template('docs.model', 'laravel-generator');
+        $docsTemplate = fill_template($this->commandData->dynamicVars, $docsTemplate);
+
+        $fillables = $oldField = '';
+        $count = 1;
+        foreach ($this->commandData->relations as $relation) {
+            $field = $relationText = (isset($relation->inputs[1])) ? $relation->inputs[1] : null;
+
+            if ($field == $oldField) {
+                $relationText = $relationText.'_'.$count;
+                $count++;
+            }
+            $oldField = $field;
+            $fillables .= ' * @property '.$this->getPHPDocType($relation->type, $relation, $relationText).PHP_EOL;
+        }
+        foreach ($this->commandData->fields as $field) {
+            if ($field->isFillable) {
+                $fillables .= ' * @property '.$this->getPHPDocType($field->fieldType).' '.$field->name.PHP_EOL;
+            }
+        }
+        $docsTemplate = str_replace('$GENERATE_DATE$', date('F j, Y, g:i a T'), $docsTemplate);
+        $docsTemplate = str_replace('$PHPDOC$', $fillables, $docsTemplate);
+
+        $templateData = str_replace('$DOCS$', $docsTemplate, $templateData);
 
         return $templateData;
     }
@@ -147,27 +155,29 @@ class ModelGenerator extends BaseGenerator
     /**
      * @param $db_type
      * @param GeneratorFieldRelation|null $relation
+     * @param string|null $relationText
      *
      * @return string
      */
-    private function getPHPDocType($db_type, $relation = null)
+    private function getPHPDocType($db_type, $relation = null, $relationText = null)
     {
+        $relationText = (!empty($relationText)) ? $relationText : null;
         switch ($db_type) {
             case 'datetime':
                 return 'string|\Carbon\Carbon';
             case '1t1':
                 return '\\'.$this->commandData->config->nsModel.'\\'.$relation->inputs[0].' '.Str::camel($relation->inputs[0]);
             case 'mt1':
-                if (isset($relation->inputs[1])) {
-                    $relationName = str_replace('_id', '', strtolower($relation->inputs[1]));
+                if (isset($relationText)) {
+                    $relationName = str_replace('_id', '', strtolower($relationText));
                 } else {
                     $relationName = $relation->inputs[0];
                 }
 
                 return '\\'.$this->commandData->config->nsModel.'\\'.$relation->inputs[0].' '.Str::camel($relationName);
             case '1tm':
-                if (isset($relation->inputs[1])) {
-                    $relationName = str_replace('_id', '', strtolower($relation->inputs[1]));
+                if (isset($relationText)) {
+                    $relationName = str_replace('_id', '', strtolower($relationText));
                 } else {
                     $relationName = $relation->inputs[0];
                 }
@@ -326,9 +336,19 @@ class ModelGenerator extends BaseGenerator
     {
         $relations = [];
 
+        $count = 1;
+        $oldField = null;
         foreach ($this->commandData->relations as $relation) {
-            $relationText = $relation->getRelationFunctionText();
+            $field = (isset($relation->inputs[1])) ? $relation->inputs[1] : null ;
+
+            $relationShipText = $field;
+            if ($field == $oldField) {
+                $relationShipText = $relationShipText.'_'.$count;
+                $count++;
+            }
+            $relationText = $relation->getRelationFunctionText($relationShipText);
             if (!empty($relationText)) {
+                $oldField = $field;
                 $relations[] = $relationText;
             }
         }

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -168,7 +168,7 @@ class ModelGenerator extends BaseGenerator
             case 'datetime':
                 return 'string|\Carbon\Carbon';
             case '1t1':
-                return '\\'.$this->commandData->config->nsModel.'\\'.$relationText.' '.Str::camel($relationText);
+                return '\\'.$this->commandData->config->nsModel.'\\'.$relation->inputs[0].' '.Str::camel($relationText);
             case 'mt1':
                 if (isset($relation->inputs[1])) {
                     $relationName = str_replace('_id', '', strtolower($relation->inputs[1]));
@@ -176,7 +176,7 @@ class ModelGenerator extends BaseGenerator
                     $relationName = $relationText;
                 }
 
-                return '\\'.$this->commandData->config->nsModel.'\\'.$relationText.' '.Str::camel($relationName);
+                return '\\'.$this->commandData->config->nsModel.'\\'.$relation->inputs[0].' '.Str::camel($relationName);
             case '1tm':
             case 'mtm':
             case 'hmt':

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -127,17 +127,18 @@ class ModelGenerator extends BaseGenerator
         $docsTemplate = get_template('docs.model', 'laravel-generator');
         $docsTemplate = fill_template($this->commandData->dynamicVars, $docsTemplate);
 
-        $fillables = $oldField = '';
+        $fillables = '';
+        $fieldsArr = [];
         $count = 1;
         foreach ($this->commandData->relations as $relation) {
             $field = $relationText = (isset($relation->inputs[0])) ? $relation->inputs[0] : null;
-            if ($field == $oldField) {
+            if (in_array($field, $fieldsArr)) {
                 $relationText = $relationText.'_'.$count;
                 $count++;
             }
 
             $fillables .= ' * @property '.$this->getPHPDocType($relation->type, $relation, $relationText).PHP_EOL;
-            $oldField = $field;
+            $fieldsArr[] = $field;
         }
 
         foreach ($this->commandData->fields as $field) {
@@ -332,19 +333,19 @@ class ModelGenerator extends BaseGenerator
         $relations = [];
 
         $count = 1;
-        $oldField = null;
+        $fieldsArr = [];
         foreach ($this->commandData->relations as $relation) {
             $field = (isset($relation->inputs[0])) ? $relation->inputs[0] : null;
 
             $relationShipText = $field;
-            if ($field == $oldField) {
+            if (in_array($field, $fieldsArr)) {
                 $relationShipText = $relationShipText.'_'.$count;
                 $count++;
             }
 
             $relationText = $relation->getRelationFunctionText($relationShipText);
             if (!empty($relationText)) {
-                $oldField = $field;
+                $fieldsArr[] = $field;
                 $relations[] = $relationText;
             }
         }


### PR DESCRIPTION
How to  reproduce : #709 

**NOTE: `1tm` relation text should be taken from table name instead of column names.**


while we have migration like following:

 ```
public function up()
    {
        Schema::create('people', function (Blueprint $table) {
            $table->bigIncrements('id');
            $table->string('name');
            $table->timestamps();
        });

        Schema::create('phones', function (Blueprint $table) {
            $table->bigIncrements('id');
            $table->string('phone_no');
            $table->unsignedBigInteger('people_id')->nullable();
            $table->timestamps();

            $table->foreign('people_id')->references('id')->on('people');
        });

        Schema::create('addresses', function (Blueprint $table) {
            $table->bigIncrements('id');
            $table->string('address');
            $table->unsignedBigInteger('people_id')->nullable();

            $table->foreign('people_id')->references('id')->on('people');
        });

        Schema::create('cities', function (Blueprint $table) {
            $table->bigIncrements('id');
            $table->string('name');
            $table->unsignedBigInteger('people_id')->nullable();
            $table->foreign('people_id')->references('id')->on('people');
        });
    }

```

after running command `php artisan infyom:scaffold People --fromTable --tableName=people`, 

Now people model has three same relation with names `function people()`

Solution:
after applying this PR changes duplicate relations look like,

  ```
/**
     * @return \Illuminate\Database\Eloquent\Relations\HasMany
     **/
    public function phones()
    {
        return $this->hasMany(\App\Models\Phone::class, 'people_id');
    }

    /**
     * @return \Illuminate\Database\Eloquent\Relations\HasMany
     **/
    public function addresses()
    {
        return $this->hasMany(\App\Models\Address::class, 'people_id');
    }

    /**
     * @return \Illuminate\Database\Eloquent\Relations\HasMany
     **/
    public function cities()
    {
        return $this->hasMany(\App\Models\City::class, 'people_id');
    } 
```