### PR TITLE
FatalThrowableError with GeneratorField

### DIFF
--- a/src/Generators/VueJs/ViewGenerator.php
+++ b/src/Generators/VueJs/ViewGenerator.php
@@ -154,8 +154,8 @@ class ViewGenerator extends BaseGenerator
 
                 case 'checkbox':
                     $fieldTemplate = get_template('vuejs.fields.checkbox', $this->templateType);
-                    $checkboxValue = $value = $field['htmlTypeInputs'];
-                    if ($field['fieldType'] != 'boolean') {
+                    $checkboxValue = $value = $field->htmlTypeInputs;
+                    if ($field->fieldType != 'boolean') {
                         $checkboxValue = "'".$value."'";
                     }
                     $fieldTemplate = str_replace('$CHECKBOX_VALUE$', $checkboxValue, $fieldTemplate);


### PR DESCRIPTION
Symfony\Component\Debug\Exception\FatalThrowableError  : Cannot use object of type InfyOm\Generator\Common\GeneratorField as array.

> 158|                     $checkboxValue = $value = $field['htmlType'];