### PR TITLE
feat: exclude filed from show page support added with option InView (#734)

### DIFF
--- a/samples/fields_sample.json
+++ b/samples/fields_sample.json
@@ -8,7 +8,8 @@
         "fillable": false,
         "primary": true,
         "inForm": false,
-        "inIndex": false
+        "inIndex": false,
+        "inView": false
     },
     {
         "name": "title",
@@ -34,7 +35,8 @@
         "htmlType": "password",
         "searchable": false,
         "inForm": false,
-        "inIndex": false
+        "inIndex": false,
+        "inView": false
     },
     {
         "name": "token",
@@ -42,7 +44,8 @@
         "htmlType": "hidden",
         "searchable": false,
         "inForm": false,
-        "inIndex": false
+        "inIndex": false,
+        "inView": false
     },
     {
         "name": "email",

--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -205,6 +205,7 @@ class BaseCommand extends Command
                 'primary'     => $field->isPrimary,
                 'inForm'      => $field->inForm,
                 'inIndex'     => $field->inIndex,
+                'inView'      => $field->inView,
             ];
         }
 

--- a/src/Common/GeneratorField.php
+++ b/src/Common/GeneratorField.php
@@ -28,6 +28,7 @@ class GeneratorField
     public $isPrimary = false;
     public $inForm = true;
     public $inIndex = true;
+    public $inView = true;
     public $isNotNull = false;
 
     public function parseDBType($dbInput)
@@ -70,6 +71,7 @@ class GeneratorField
             $this->isFillable = false;
             $this->inForm = false;
             $this->inIndex = false;
+            $this->inView = false;
         }
         if (in_array('f', $optionsArr)) {
             $this->isFillable = false;
@@ -79,6 +81,9 @@ class GeneratorField
         }
         if (in_array('ii', $optionsArr)) {
             $this->inIndex = false;
+        }
+        if (in_array('iv', $optionsArr)) {
+            $this->inView = false;
         }
     }
 
@@ -136,6 +141,7 @@ class GeneratorField
         $field->isPrimary = isset($fieldInput['primary']) ? $fieldInput['primary'] : false;
         $field->inForm = isset($fieldInput['inForm']) ? $fieldInput['inForm'] : true;
         $field->inIndex = isset($fieldInput['inIndex']) ? $fieldInput['inIndex'] : true;
+        $field->inView = isset($fieldInput['inView']) ? $fieldInput['inView'] : true;
 
         return $field;
     }

--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -242,7 +242,6 @@ class ViewGenerator extends BaseGenerator
         $fieldsStr = '';
 
         foreach ($this->commandData->fields as $field) {
-
             if (!$field->inView) {
                 continue;
             }

--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -242,6 +242,10 @@ class ViewGenerator extends BaseGenerator
         $fieldsStr = '';
 
         foreach ($this->commandData->fields as $field) {
+
+            if (!$field->inView) {
+                continue;
+            }
             $singleFieldStr = str_replace('$FIELD_NAME_TITLE$', Str::title(str_replace('_', ' ', $field->name)),
                 $fieldTemplate);
             $singleFieldStr = str_replace('$FIELD_NAME$', $field->name, $singleFieldStr);

--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -149,6 +149,7 @@ class TableFieldsGenerator
                 $field->isFillable = false;
                 $field->inForm = false;
                 $field->inIndex = false;
+                $field->inView = false;
             }
             $field->isNotNull = (bool) $column->getNotNull();
             $field->description = $column->getComment(); // get comments from table
@@ -233,6 +234,7 @@ class TableFieldsGenerator
             $field->isSearchable = false;
             $field->inIndex = false;
             $field->inForm = false;
+            $field->inView = false;
         }
 
         return $field;

--- a/tests/Utils/GeneratorFieldsInputUtilTest.php
+++ b/tests/Utils/GeneratorFieldsInputUtilTest.php
@@ -42,6 +42,7 @@ class GeneratorFieldsInputUtilTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($res->isPrimary);
         $this->assertTrue($res->inForm);
         $this->assertTrue($res->inIndex);
+        $this->assertTrue($res->inView);
 
         // name string,20 textarea
         $input = 'name string,20 textarea';
@@ -95,6 +96,7 @@ class GeneratorFieldsInputUtilTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($res->isPrimary);
         $this->assertFalse($res->inForm);
         $this->assertTrue($res->inIndex);
+        $this->assertTrue($res->inView);
     }
 
     public function testPrepareKeyValueArrayStr()


### PR DESCRIPTION
### What done?
 * exclude filed from show page support added by option.  issue found [here](https://github.com/InfyOmLabs/laravel-generator/issues/734)
* InView option added for generate by json file.
**Example**
by json file
 ```
{
        "name": "checkbox",
        "dbType": "integer",
        "htmlType": "checkbox",
        "validations": "required",
        "searchable": true,
        "fillable": true,
        "primary": false,
        "inForm": true,
        "inIndex": true,
        "inView": false" // this option added
 },
```
by terminal 
` body text textarea iv`  // you can skip filed from view using `iv`

### How to Test
![image](https://user-images.githubusercontent.com/28335166/65318182-cfe80480-dbba-11e9-9bfb-e7b9503bdc5b.png)

![image](https://user-images.githubusercontent.com/28335166/65318250-ec843c80-dbba-11e9-9979-d743c9f5bb6b.png)



