### PR TITLE
feat: #715 read length and nullable from table and add in a json file

### DIFF
--- a/src/Common/GeneratorField.php
+++ b/src/Common/GeneratorField.php
@@ -34,15 +34,15 @@ class GeneratorField
      * @param Column $column
      * @param $dbInput
      */
-    public function parseDBType($dbInput, $column= null)
+    public function parseDBType($dbInput, $column = null)
     {
         $this->dbInput = $dbInput;
         if (!is_null($column)) {
             if ($column->getLength() > 0) {
-                $this->dbInput = $this->dbInput . ',' . $column->getLength();
+                $this->dbInput = $this->dbInput.','.$column->getLength();
             }
             if (!$column->getNotnull()) {
-                $this->dbInput = $this->dbInput . ':nullable';
+                $this->dbInput = $this->dbInput.':nullable';
             }
         }
         $this->prepareMigrationText();

--- a/src/Common/GeneratorField.php
+++ b/src/Common/GeneratorField.php
@@ -30,9 +30,21 @@ class GeneratorField
     public $inIndex = true;
     public $isNotNull = false;
 
-    public function parseDBType($dbInput)
+    /**
+     * @param Column $column
+     * @param $dbInput
+     */
+    public function parseDBType($dbInput, $column= null)
     {
         $this->dbInput = $dbInput;
+        if (!is_null($column)) {
+            if ($column->getLength() > 0) {
+                $this->dbInput = $this->dbInput . ',' . $column->getLength();
+            }
+            if (!$column->getNotnull()) {
+                $this->dbInput = $this->dbInput . ':nullable';
+            }
+        }
         $this->prepareMigrationText();
     }
 

--- a/src/Common/GeneratorField.php
+++ b/src/Common/GeneratorField.php
@@ -38,12 +38,8 @@ class GeneratorField
     {
         $this->dbInput = $dbInput;
         if (!is_null($column)) {
-            if ($column->getLength() > 0) {
-                $this->dbInput = $this->dbInput.','.$column->getLength();
-            }
-            if (!$column->getNotnull()) {
-                $this->dbInput = $this->dbInput.':nullable';
-            }
+            $this->dbInput = ($column->getLength() > 0) ? $this->dbInput.','.$column->getLength() : $this->dbInput;
+            $this->dbInput = (!$column->getNotnull()) ? $this->dbInput.':nullable' : $this->dbInput;
         }
         $this->prepareMigrationText();
     }

--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -251,7 +251,7 @@ class TableFieldsGenerator
     {
         $field = new GeneratorField();
         $field->name = $column->getName();
-        $field->parseDBType($dbType);
+        $field->parseDBType($dbType, $column);
         $field->parseHtmlInput($htmlType);
 
         return $this->checkForPrimary($field);


### PR DESCRIPTION
### What change done?
field's length read from db schema and write into json file 
read field is nulable or not from db schema and write into json file 

here is command...
`php artisan infyom:scaffold A --fromTable --tableName=a --plural=a --skip=migration,controllers,api_controller,scaffold_controller,scaffold_requests,routes,api_routes,scaffold_routes,views,tests,menu,dump-autoload,model,repository -n

**Example**
```
{
    "name": "category",
    "dbType": "string,30:nullable",  // here write from DB
    "htmlType": "select,Technology,LifeStyle,Education,Games",
    "searchable": true
 }
```
for more info found [here](https://github.com/InfyOmLabs/laravel-generator/issues/715)