### PR TITLE
#733 add min|max validations to html field

### DIFF
--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -206,10 +206,15 @@ class ViewGenerator extends BaseGenerator
                     continue;
                 }
 
+                $validationText = substr($validation, 0, 3);
                 $sizeInNumber = substr($validation, 4);
-                $sizeText = substr($validation, 0, 3) == 'min' ? 'minlength' : 'maxlength';
-                $size = ",'$sizeText' => $sizeInNumber";
 
+                $sizeText = ($validationText == 'min') ? 'minlength' : 'maxlength';
+                if ($field->htmlType == 'number') {
+                    $sizeText = $validationText;
+                }
+
+                $size = ",'$sizeText' => $sizeInNumber";
                 $minMaxRules .= $size;
             }
             $this->commandData->addDynamicVariable('$SIZE$', $minMaxRules);

--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -200,16 +200,19 @@ class ViewGenerator extends BaseGenerator
             }
 
             $validations = explode('|', $field->validations);
-            usort($validations, function ($record) {
-                return (Str::contains($record, ['max:', 'min:'])) ? 0 : 1;
-            });
-            $size = (Str::contains($validations[0], ['max:', 'min:'])) ? $validations[0] : '';
-            if (!empty($size)) {
-                $sizeInNumber = substr($size, 4);
-                $sizeText = (substr($size, 0, 3) == 'min') ? 'minlength' : 'maxlength';
-                $size = ", '$sizeText' => $sizeInNumber";
+            $minMaxRules = '';
+            foreach ($validations as $validation) {
+                if (!Str::contains($validation, ['max:', 'min:'])) {
+                    continue;
+                }
+
+                $sizeInNumber = substr($validation, 4);
+                $sizeText = substr($validation, 0, 3) == 'min' ? 'minlength' : 'maxlength';
+                $size = ",'$sizeText' => $sizeInNumber";
+
+                $minMaxRules .= $size;
             }
-            $this->commandData->addDynamicVariable('$SIZE$', $size);
+            $this->commandData->addDynamicVariable('$SIZE$', $minMaxRules);
 
             $fieldTemplate = HTMLFieldGenerator::generateHTML($field, $this->templateType);
 

--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -199,6 +199,18 @@ class ViewGenerator extends BaseGenerator
                 continue;
             }
 
+            $validations = explode('|', $field->validations);
+            usort($validations, function ($record) {
+                return (Str::contains($record, ['max:', 'min:'])) ? 0 : 1;
+            });
+            $size = (Str::contains($validations[0], ['max:', 'min:'])) ? $validations[0] : '';
+            if (!empty($size)) {
+                $sizeInNumber = substr($size, 4);
+                $sizeText = substr($size, 0, 3);
+                $size = ", '$sizeText' => $sizeInNumber";
+            }
+            $this->commandData->addDynamicVariable('$SIZE$', $size);
+
             $fieldTemplate = HTMLFieldGenerator::generateHTML($field, $this->templateType);
 
             if (!empty($fieldTemplate)) {

--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -206,7 +206,7 @@ class ViewGenerator extends BaseGenerator
             $size = (Str::contains($validations[0], ['max:', 'min:'])) ? $validations[0] : '';
             if (!empty($size)) {
                 $sizeInNumber = substr($size, 4);
-                $sizeText = substr($size, 0, 3);
+                $sizeText = (substr($size, 0, 3) == 'min') ? 'minlength' : 'maxlength';
                 $size = ", '$sizeText' => $sizeInNumber";
             }
             $this->commandData->addDynamicVariable('$SIZE$', $size);


### PR DESCRIPTION
https://github.com/InfyOmLabs/laravel-generator/issues/733

`min` and `max` rules now validate from html field too.

How  to test ?

change generator branch to  `vishal/733_validations` and adminlte-template branch to `vishal/733` then run `composer update`

Create any module with rules `min:5` OR `max:5` and check related HTML field 