### PR TITLE
Publish User Crud with default fields

### DIFF
--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -31,9 +31,9 @@ class PublishUserCommand extends PublishBaseCommand
         $this->updateRoutes();
         $this->updateMenu();
         $this->publishUserController();
-		if (config('infyom.laravel_generator.option.repository_pattern')) {
-           $this->publishUserRepository();
-		}
+        if (config('infyom.laravel_generator.option.repository_pattern')) {
+            $this->publishUserRepository();
+        }
         $this->publishCreateUserRequest();
         $this->publishUpdateUserRequest();
     }

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -104,6 +104,7 @@ class PublishUserCommand extends PublishBaseCommand
         $templateData = get_template('user/user_controller', 'laravel-generator');
         if (!config('infyom.laravel_generator.options.repository_pattern')) {
             $templateData = get_template('user/user_controller_without_repository', 'laravel-generator');
+            $templateData = $this->fillTemplate($templateData);
         }
 
         $templateData = $this->fillTemplate($templateData);
@@ -195,6 +196,7 @@ class PublishUserCommand extends PublishBaseCommand
         $templateData = str_replace('$NAMESPACE_REQUEST$', config('infyom.laravel_generator.namespace.request'), $templateData);
 
         $templateData = str_replace('$NAMESPACE_REPOSITORY$', config('infyom.laravel_generator.namespace.repository'), $templateData);
+        $templateData = str_replace('$NAMESPACE_USER$', config('auth.providers.users.model'), $templateData);
 
         return $templateData;
     }

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -31,9 +31,9 @@ class PublishUserCommand extends PublishBaseCommand
         $this->updateRoutes();
         $this->updateMenu();
         $this->publishUserController();
-if (config('infyom.laravel_generator.option.repository_pattern')) {
-        $this->publishUserRepository();
-}
+		if (config('infyom.laravel_generator.option.repository_pattern')) {
+           $this->publishUserRepository();
+		}
         $this->publishCreateUserRequest();
         $this->publishUpdateUserRequest();
     }

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -100,6 +100,9 @@ class PublishUserCommand extends PublishBaseCommand
     private function publishUserController()
     {
         $templateData = get_template('user/user_controller', 'laravel-generator');
+        if(!config('infyom.laravel_generator.option.repository_pattern')){
+            $templateData = get_template('user/user_controller_without_repository', 'laravel-generator');
+        }
 
         $templateData = $this->fillTemplate($templateData);
 

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace InfyOm\Generator\Commands\Publish;
+
+use InfyOm\Generator\Utils\FileUtil;
+
+class PublishUserCommand extends PublishBaseCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'infyom.publish:user';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Publishes users files';
+
+    /**
+     * Execute the command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->copyView();
+        $this->updateRoutes();
+        $this->publishUserController();
+        $this->publishUserRepository();
+        $this->publishCreateUserRequest();
+        $this->publishUpdateUserRequest();
+    }
+
+    private function copyView()
+    {
+        $viewsPath    = config('infyom.laravel_generator.path.views', resource_path('views/'));
+        $templateType = config('infyom.laravel_generator.templates', 'adminlte-templates');
+
+        $this->createDirectories($viewsPath . 'users');
+
+        $files = $this->getViews();
+
+        foreach ($files as $stub => $blade) {
+            $sourceFile      = get_template($stub, $templateType);
+            $destinationFile = $viewsPath . $blade;
+            $this->publishFile($sourceFile, $destinationFile, $blade);
+        }
+    }
+
+    private function createDirectories($dir)
+    {
+        FileUtil::createDirectoryIfNotExist($dir);
+    }
+
+    private function getViews()
+    {
+        return ['users/create' => 'users/create.blade.php', 'users/edit' => 'users/edit.blade.php', 'users/fields' => 'users/fields.blade.php', 'users/index' => 'users/index.blade.php', 'users/show' => 'users/show.blade.php', 'users/show_fields' => 'users/show_fields.blade.php', 'users/table' => 'users/table.blade.php',];
+    }
+
+    private function updateRoutes()
+    {
+        $path = config('infyom.laravel_generator.path.routes', base_path('routes/web.php'));
+
+        $prompt = 'Existing routes web.php file detected. Should we add standard auth routes? (y|N) :';
+        if (file_exists($path) && !$this->confirmOverwrite($path, $prompt)) {
+            return;
+        }
+
+        $routeContents = file_get_contents($path);
+
+        $routesTemplate = get_template('routes.user', 'laravel-generator');
+
+        $routeContents .= "\n\n" . $routesTemplate;
+
+        file_put_contents($path, $routeContents);
+        $this->comment("\nUser route added");
+    }
+
+    private function publishUserController()
+    {
+        $templateData = get_template('user/user_controller', 'laravel-generator');
+
+        $templateData = $this->fillTemplate($templateData);
+
+        $controllerPath = config('infyom.laravel_generator.path.controller', app_path('Http/Controllers/'));
+
+        $fileName = 'UserController.php';
+
+        if (file_exists($controllerPath . $fileName) && !$this->confirmOverwrite($fileName)) {
+            return;
+        }
+
+        FileUtil::createFile($controllerPath, $fileName, $templateData);
+
+        $this->info('UserController created');
+    }
+
+    private function publishUserRepository()
+    {
+        $templateData = get_template('user/user_repository', 'laravel-generator');
+
+        $templateData = $this->fillTemplate($templateData);
+
+        $repositoryPath = config('infyom.laravel_generator.path.repository', app_path('Repositories/'));
+
+        $fileName = 'UserRepository.php';
+
+        FileUtil::createDirectoryIfNotExist($repositoryPath);
+
+        if (file_exists($repositoryPath . $fileName) && !$this->confirmOverwrite($fileName)) {
+            return;
+        }
+
+        FileUtil::createFile($repositoryPath, $fileName, $templateData);
+
+        $this->info('UserRepository created');
+    }
+
+    private function publishCreateUserRequest()
+    {
+        $templateData = get_template('user/create_user_request', 'laravel-generator');
+
+        $templateData = $this->fillTemplate($templateData);
+
+        $requestPath = config('infyom.laravel_generator.path.request', app_path('Http/Requests/'));
+
+        $fileName = 'CreateUserRequest.php';
+
+        FileUtil::createDirectoryIfNotExist($requestPath);
+
+        if (file_exists($requestPath . $fileName) && !$this->confirmOverwrite($fileName)) {
+            return;
+        }
+
+        FileUtil::createFile($requestPath, $fileName, $templateData);
+
+        $this->info('CreateUserRequest created');
+    }
+
+    private function publishUpdateUserRequest()
+    {
+        $templateData = get_template('user/update_user_request', 'laravel-generator');
+
+        $templateData = $this->fillTemplate($templateData);
+
+        $requestPath = config('infyom.laravel_generator.path.request', app_path('Http/Requests/'));
+
+        $fileName = 'UpdateUserRequest.php';
+        if (file_exists($requestPath . $fileName) && !$this->confirmOverwrite($fileName)) {
+            return;
+        }
+
+        FileUtil::createFile($requestPath, $fileName, $templateData);
+
+        $this->info('UpdateUserRequest created');
+    }
+
+    /**
+     * Replaces dynamic variables of template.
+     *
+     * @param string $templateData
+     *
+     * @return string
+     */
+    private function fillTemplate($templateData)
+    {
+        $templateData = str_replace('$NAMESPACE_CONTROLLER$', config('infyom.laravel_generator.namespace.controller'), $templateData);
+
+        $templateData = str_replace('$NAMESPACE_REQUEST$', config('infyom.laravel_generator.namespace.request'), $templateData);
+
+        $templateData = str_replace('$NAMESPACE_REPOSITORY$', config('infyom.laravel_generator.namespace.repository'), $templateData);
+
+        return $templateData;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    public function getOptions()
+    {
+        return [];
+    }
+
+    /**
+     * Get the console command arguments.
+     *
+     * @return array
+     */
+    protected function getArguments()
+    {
+        return [];
+    }
+}

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -29,6 +29,7 @@ class PublishUserCommand extends PublishBaseCommand
     {
         $this->copyView();
         $this->updateRoutes();
+        $this->updateMenu();
         $this->publishUserController();
         $this->publishUserRepository();
         $this->publishCreateUserRequest();

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -80,6 +80,21 @@ class PublishUserCommand extends PublishBaseCommand
         $this->comment("\nUser route added");
     }
 
+    private function updateMenu()
+    {
+        if (config('infyom.laravel_generator.add_on.menu.enabled')) {
+            $viewsPath    = config('infyom.laravel_generator.path.views', resource_path('views/'));
+            $templateType = config('infyom.laravel_generator.templates', 'adminlte-templates');
+            $path         = $viewsPath . 'layouts/menu.blade.php';
+            $menuContents = file_get_contents($path);
+            $sourceFile   = get_template_file_path('scaffold/users/menu', $templateType);
+            $menuContents .= "\n\n" . $sourceFile;
+
+            file_put_contents($path, $menuContents);
+            $this->comment("\nUser Menu added");
+        }
+    }
+
     private function publishUserController()
     {
         $templateData = get_template('user/user_controller', 'laravel-generator');

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -18,7 +18,7 @@ class PublishUserCommand extends PublishBaseCommand
      *
      * @var string
      */
-    protected $description = 'Publishes users files';
+    protected $description = 'Publishes Users CRUD file';
 
     /**
      * Execute the command.
@@ -27,7 +27,7 @@ class PublishUserCommand extends PublishBaseCommand
      */
     public function handle()
     {
-        $this->copyView();
+        $this->copyViews();
         $this->updateRoutes();
         $this->updateMenu();
         $this->publishUserController();
@@ -38,7 +38,7 @@ class PublishUserCommand extends PublishBaseCommand
         $this->publishUpdateUserRequest();
     }
 
-    private function copyView()
+    private function copyViews()
     {
         $viewsPath = config('infyom.laravel_generator.path.views', resource_path('views/'));
         $templateType = config('infyom.laravel_generator.templates', 'adminlte-templates');

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -100,7 +100,7 @@ class PublishUserCommand extends PublishBaseCommand
     private function publishUserController()
     {
         $templateData = get_template('user/user_controller', 'laravel-generator');
-        if(!config('infyom.laravel_generator.option.repository_pattern')){
+        if (!config('infyom.laravel_generator.option.repository_pattern')) {
             $templateData = get_template('user/user_controller_without_repository', 'laravel-generator');
         }
 

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -83,17 +83,15 @@ class PublishUserCommand extends PublishBaseCommand
 
     private function updateMenu()
     {
-        if (config('infyom.laravel_generator.add_on.menu.enabled')) {
-            $viewsPath    = config('infyom.laravel_generator.path.views', resource_path('views/'));
-            $templateType = config('infyom.laravel_generator.templates', 'adminlte-templates');
-            $path         = $viewsPath . 'layouts/menu.blade.php';
-            $menuContents = file_get_contents($path);
-            $sourceFile   = get_template_file_path('scaffold/users/menu', $templateType);
-            $menuContents .= "\n\n" . $sourceFile;
+        $viewsPath    = config('infyom.laravel_generator.path.views', resource_path('views/'));
+        $templateType = config('infyom.laravel_generator.templates', 'adminlte-templates');
+        $path         = $viewsPath . 'layouts/menu.blade.php';
+        $menuContents = file_get_contents($path);
+        $sourceFile   = get_template_file_path('scaffold/users/menu', $templateType);
+        $menuContents .= "\n\n" . $sourceFile;
 
-            file_put_contents($path, $menuContents);
-            $this->comment("\nUser Menu added");
-        }
+        file_put_contents($path, $menuContents);
+        $this->comment("\nUser Menu added");
     }
 
     private function publishUserController()

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -59,7 +59,15 @@ class PublishUserCommand extends PublishBaseCommand
 
     private function getViews()
     {
-        return ['users/create' => 'users/create.blade.php', 'users/edit' => 'users/edit.blade.php', 'users/fields' => 'users/fields.blade.php', 'users/index' => 'users/index.blade.php', 'users/show' => 'users/show.blade.php', 'users/show_fields' => 'users/show_fields.blade.php', 'users/table' => 'users/table.blade.php'];
+        return [
+            'users/create'      => 'users/create.blade.php',
+            'users/edit'        => 'users/edit.blade.php',
+            'users/fields'      => 'users/fields.blade.php',
+            'users/index'       => 'users/index.blade.php',
+            'users/show'        => 'users/show.blade.php',
+            'users/show_fields' => 'users/show_fields.blade.php',
+            'users/table'       => 'users/table.blade.php',
+        ];
     }
 
     private function updateRoutes()

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -31,7 +31,7 @@ class PublishUserCommand extends PublishBaseCommand
         $this->updateRoutes();
         $this->updateMenu();
         $this->publishUserController();
-        if (config('infyom.laravel_generator.option.repository_pattern')) {
+        if (config('infyom.laravel_generator.options.repository_pattern')) {
             $this->publishUserRepository();
         }
         $this->publishCreateUserRequest();
@@ -102,7 +102,7 @@ class PublishUserCommand extends PublishBaseCommand
     private function publishUserController()
     {
         $templateData = get_template('user/user_controller', 'laravel-generator');
-        if (!config('infyom.laravel_generator.option.repository_pattern')) {
+        if (!config('infyom.laravel_generator.options.repository_pattern')) {
             $templateData = get_template('user/user_controller_without_repository', 'laravel-generator');
         }
 

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -74,11 +74,6 @@ class PublishUserCommand extends PublishBaseCommand
     {
         $path = config('infyom.laravel_generator.path.routes', base_path('routes/web.php'));
 
-        $prompt = 'Existing routes web.php file detected. Should we add standard auth routes? (y|N) :';
-        if (file_exists($path) && !$this->confirmOverwrite($path, $prompt)) {
-            return;
-        }
-
         $routeContents = file_get_contents($path);
 
         $routesTemplate = get_template('routes.user', 'laravel-generator');

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -45,7 +45,7 @@ class PublishUserCommand extends PublishBaseCommand
         $files = $this->getViews();
 
         foreach ($files as $stub => $blade) {
-            $sourceFile      = get_template($stub, $templateType);
+            $sourceFile      = get_template_file_path('scaffold/' . $stub, $templateType);
             $destinationFile = $viewsPath . $blade;
             $this->publishFile($sourceFile, $destinationFile, $blade);
         }

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -31,7 +31,9 @@ class PublishUserCommand extends PublishBaseCommand
         $this->updateRoutes();
         $this->updateMenu();
         $this->publishUserController();
+if (config('infyom.laravel_generator.option.repository_pattern')) {
         $this->publishUserRepository();
+}
         $this->publishCreateUserRequest();
         $this->publishUpdateUserRequest();
     }

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -87,8 +87,8 @@ class PublishUserCommand extends PublishBaseCommand
         $templateType = config('infyom.laravel_generator.templates', 'adminlte-templates');
         $path         = $viewsPath . 'layouts/menu.blade.php';
         $menuContents = file_get_contents($path);
-        $sourceFile   = get_template_file_path('scaffold/users/menu', $templateType);
-        $menuContents .= "\n\n" . $sourceFile;
+        $sourceFile   = file_get_contents(get_template_file_path('scaffold/users/menu', $templateType));
+        $menuContents .= "\n" . $sourceFile;
 
         file_put_contents($path, $menuContents);
         $this->comment("\nUser Menu added");

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -38,16 +38,16 @@ class PublishUserCommand extends PublishBaseCommand
 
     private function copyView()
     {
-        $viewsPath    = config('infyom.laravel_generator.path.views', resource_path('views/'));
+        $viewsPath = config('infyom.laravel_generator.path.views', resource_path('views/'));
         $templateType = config('infyom.laravel_generator.templates', 'adminlte-templates');
 
-        $this->createDirectories($viewsPath . 'users');
+        $this->createDirectories($viewsPath.'users');
 
         $files = $this->getViews();
 
         foreach ($files as $stub => $blade) {
-            $sourceFile      = get_template_file_path('scaffold/' . $stub, $templateType);
-            $destinationFile = $viewsPath . $blade;
+            $sourceFile = get_template_file_path('scaffold/'.$stub, $templateType);
+            $destinationFile = $viewsPath.$blade;
             $this->publishFile($sourceFile, $destinationFile, $blade);
         }
     }
@@ -59,7 +59,7 @@ class PublishUserCommand extends PublishBaseCommand
 
     private function getViews()
     {
-        return ['users/create' => 'users/create.blade.php', 'users/edit' => 'users/edit.blade.php', 'users/fields' => 'users/fields.blade.php', 'users/index' => 'users/index.blade.php', 'users/show' => 'users/show.blade.php', 'users/show_fields' => 'users/show_fields.blade.php', 'users/table' => 'users/table.blade.php',];
+        return ['users/create' => 'users/create.blade.php', 'users/edit' => 'users/edit.blade.php', 'users/fields' => 'users/fields.blade.php', 'users/index' => 'users/index.blade.php', 'users/show' => 'users/show.blade.php', 'users/show_fields' => 'users/show_fields.blade.php', 'users/table' => 'users/table.blade.php'];
     }
 
     private function updateRoutes()
@@ -75,7 +75,7 @@ class PublishUserCommand extends PublishBaseCommand
 
         $routesTemplate = get_template('routes.user', 'laravel-generator');
 
-        $routeContents .= "\n\n" . $routesTemplate;
+        $routeContents .= "\n\n".$routesTemplate;
 
         file_put_contents($path, $routeContents);
         $this->comment("\nUser route added");
@@ -83,12 +83,12 @@ class PublishUserCommand extends PublishBaseCommand
 
     private function updateMenu()
     {
-        $viewsPath    = config('infyom.laravel_generator.path.views', resource_path('views/'));
+        $viewsPath = config('infyom.laravel_generator.path.views', resource_path('views/'));
         $templateType = config('infyom.laravel_generator.templates', 'adminlte-templates');
-        $path         = $viewsPath . 'layouts/menu.blade.php';
+        $path = $viewsPath.'layouts/menu.blade.php';
         $menuContents = file_get_contents($path);
-        $sourceFile   = file_get_contents(get_template_file_path('scaffold/users/menu', $templateType));
-        $menuContents .= "\n" . $sourceFile;
+        $sourceFile = file_get_contents(get_template_file_path('scaffold/users/menu', $templateType));
+        $menuContents .= "\n".$sourceFile;
 
         file_put_contents($path, $menuContents);
         $this->comment("\nUser Menu added");
@@ -104,7 +104,7 @@ class PublishUserCommand extends PublishBaseCommand
 
         $fileName = 'UserController.php';
 
-        if (file_exists($controllerPath . $fileName) && !$this->confirmOverwrite($fileName)) {
+        if (file_exists($controllerPath.$fileName) && !$this->confirmOverwrite($fileName)) {
             return;
         }
 
@@ -125,7 +125,7 @@ class PublishUserCommand extends PublishBaseCommand
 
         FileUtil::createDirectoryIfNotExist($repositoryPath);
 
-        if (file_exists($repositoryPath . $fileName) && !$this->confirmOverwrite($fileName)) {
+        if (file_exists($repositoryPath.$fileName) && !$this->confirmOverwrite($fileName)) {
             return;
         }
 
@@ -146,7 +146,7 @@ class PublishUserCommand extends PublishBaseCommand
 
         FileUtil::createDirectoryIfNotExist($requestPath);
 
-        if (file_exists($requestPath . $fileName) && !$this->confirmOverwrite($fileName)) {
+        if (file_exists($requestPath.$fileName) && !$this->confirmOverwrite($fileName)) {
             return;
         }
 
@@ -164,7 +164,7 @@ class PublishUserCommand extends PublishBaseCommand
         $requestPath = config('infyom.laravel_generator.path.request', app_path('Http/Requests/'));
 
         $fileName = 'UpdateUserRequest.php';
-        if (file_exists($requestPath . $fileName) && !$this->confirmOverwrite($fileName)) {
+        if (file_exists($requestPath.$fileName) && !$this->confirmOverwrite($fileName)) {
             return;
         }
 

--- a/src/InfyOmGeneratorServiceProvider.php
+++ b/src/InfyOmGeneratorServiceProvider.php
@@ -14,6 +14,7 @@ use InfyOm\Generator\Commands\Common\RepositoryGeneratorCommand;
 use InfyOm\Generator\Commands\Publish\GeneratorPublishCommand;
 use InfyOm\Generator\Commands\Publish\LayoutPublishCommand;
 use InfyOm\Generator\Commands\Publish\PublishTemplateCommand;
+use InfyOm\Generator\Commands\Publish\PublishUserCommand;
 use InfyOm\Generator\Commands\Publish\VueJsLayoutPublishCommand;
 use InfyOm\Generator\Commands\RollbackGeneratorCommand;
 use InfyOm\Generator\Commands\Scaffold\ControllerGeneratorCommand;
@@ -116,6 +117,10 @@ class InfyOmGeneratorServiceProvider extends ServiceProvider
             return new VueJsLayoutPublishCommand();
         });
 
+        $this->app->singleton('infyom.publish.user', function ($app) {
+            return new PublishUserCommand();
+        });
+
         $this->commands([
             'infyom.publish',
             'infyom.api',
@@ -135,6 +140,7 @@ class InfyOmGeneratorServiceProvider extends ServiceProvider
             'infyom.rollback',
             'infyom.vuejs',
             'infyom.publish.vuejs',
+            'infyom.publish.user'
         ]);
     }
 }

--- a/src/InfyOmGeneratorServiceProvider.php
+++ b/src/InfyOmGeneratorServiceProvider.php
@@ -140,7 +140,7 @@ class InfyOmGeneratorServiceProvider extends ServiceProvider
             'infyom.rollback',
             'infyom.vuejs',
             'infyom.publish.vuejs',
-            'infyom.publish.user'
+            'infyom.publish.user',
         ]);
     }
 }

--- a/templates/routes/user.stub
+++ b/templates/routes/user.stub
@@ -1,0 +1,1 @@
+Route::resource('users', 'UserController')->middleware('auth');

--- a/templates/user/create_user_request.stub
+++ b/templates/user/create_user_request.stub
@@ -1,0 +1,30 @@
+<?php
+
+namespace $NAMESPACE_REQUEST$;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\User;
+
+class CreateUserRequest extends FormRequest
+{
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return User::$rules;
+    }
+}

--- a/templates/user/create_user_request.stub
+++ b/templates/user/create_user_request.stub
@@ -24,11 +24,11 @@ class CreateUserRequest extends FormRequest
      */
     public function rules()
     {
-        $rules =  [
-                    'name' => 'required',
-                    'email' => 'required',
-                    'password' => 'required'
-                ];
+       $rules = [
+          'name'     => 'required',
+          'email'    => 'required|email|unique:users,email|regex:/^[\w\-\.\+]+\@[a-zA-Z0-9\.\-]+\.[a-zA-z0-9]{2,4}$/',
+          'password' => 'required'
+       ];
 
         return $rules;
     }

--- a/templates/user/create_user_request.stub
+++ b/templates/user/create_user_request.stub
@@ -25,9 +25,10 @@ class CreateUserRequest extends FormRequest
     public function rules()
     {
        $rules = [
-          'name'     => 'required',
-          'email'    => 'required|email|unique:users,email|regex:/^[\w\-\.\+]+\@[a-zA-Z0-9\.\-]+\.[a-zA-z0-9]{2,4}$/',
-          'password' => 'required'
+          'name'                  => 'required',
+          'email'                 => 'required|email|unique:users,email',
+          'password'              => 'required|confirmed',
+          'password_confirmation' => 'required'
        ];
 
         return $rules;

--- a/templates/user/create_user_request.stub
+++ b/templates/user/create_user_request.stub
@@ -27,8 +27,7 @@ class CreateUserRequest extends FormRequest
        $rules = [
           'name'                  => 'required',
           'email'                 => 'required|email|unique:users,email',
-          'password'              => 'required|confirmed',
-          'password_confirmation' => 'required'
+          'password'              => 'required|confirmed'
        ];
 
         return $rules;

--- a/templates/user/create_user_request.stub
+++ b/templates/user/create_user_request.stub
@@ -3,7 +3,6 @@
 namespace $NAMESPACE_REQUEST$;
 
 use Illuminate\Foundation\Http\FormRequest;
-use App\User;
 
 class CreateUserRequest extends FormRequest
 {
@@ -25,6 +24,12 @@ class CreateUserRequest extends FormRequest
      */
     public function rules()
     {
-        return User::$rules;
+        $rules =  [
+                    'name' => 'required',
+                    'email' => 'required',
+                    'password' => 'required'
+                ];
+
+        return $rules;
     }
 }

--- a/templates/user/update_user_request.stub
+++ b/templates/user/update_user_request.stub
@@ -27,7 +27,7 @@ class UpdateUserRequest extends FormRequest
         $id = $this->route('user');
         $rules = [
           'name'     => 'required',
-          'email'    => 'required|email|unique:users,email,'.$id.
+          'email'    => 'required|email|unique:users,email,'.$id,
           'password' => 'confirmed'
         ];
         

--- a/templates/user/update_user_request.stub
+++ b/templates/user/update_user_request.stub
@@ -3,7 +3,6 @@
 namespace $NAMESPACE_REQUEST$;
 
 use Illuminate\Foundation\Http\FormRequest;
-use App\User;
 
 class UpdateUserRequest extends FormRequest
 {
@@ -25,7 +24,10 @@ class UpdateUserRequest extends FormRequest
      */
     public function rules()
     {
-        $rules = User::$rules;
+        $rules = [
+                     'name' => 'required',
+                     'email' => 'required',
+                 ];
         
         return $rules;
     }

--- a/templates/user/update_user_request.stub
+++ b/templates/user/update_user_request.stub
@@ -26,8 +26,9 @@ class UpdateUserRequest extends FormRequest
     {
         $id = $this->route('user');
         $rules = [
-          'name'  => 'required',
-          'email' => 'required|email|unique:users,email,'.$id.'|regex:/^[\w\-\.\+]+\@[a-zA-Z0-9\.\-]+\.[a-zA-z0-9]{2,4}$/',
+          'name'     => 'required',
+          'email'    => 'required|email|unique:users,email,'.$id.
+          'password' => 'confirmed'
         ];
         
         return $rules;

--- a/templates/user/update_user_request.stub
+++ b/templates/user/update_user_request.stub
@@ -24,7 +24,7 @@ class UpdateUserRequest extends FormRequest
      */
     public function rules()
     {
-        $id = $this->route('user')->id;
+        $id = $this->route('user');
         $rules = [
           'name'  => 'required',
           'email' => 'required|email|unique:users,email,'.$id.'|regex:/^[\w\-\.\+]+\@[a-zA-Z0-9\.\-]+\.[a-zA-z0-9]{2,4}$/',

--- a/templates/user/update_user_request.stub
+++ b/templates/user/update_user_request.stub
@@ -1,0 +1,32 @@
+<?php
+
+namespace $NAMESPACE_REQUEST$;
+
+use Illuminate\Foundation\Http\FormRequest;
+use App\User;
+
+class UpdateUserRequest extends FormRequest
+{
+
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $rules = User::$rules;
+        
+        return $rules;
+    }
+}

--- a/templates/user/update_user_request.stub
+++ b/templates/user/update_user_request.stub
@@ -24,10 +24,11 @@ class UpdateUserRequest extends FormRequest
      */
     public function rules()
     {
+        $id = $this->route('user')->id;
         $rules = [
-                     'name' => 'required',
-                     'email' => 'required',
-                 ];
+          'name'  => 'required',
+          'email' => 'required|email|unique:users,email,'.$id.'|regex:/^[\w\-\.\+]+\@[a-zA-Z0-9\.\-]+\.[a-zA-z0-9]{2,4}$/',
+        ];
         
         return $rules;
     }

--- a/templates/user/user_controller.stub
+++ b/templates/user/user_controller.stub
@@ -1,0 +1,155 @@
+<?php
+
+namespace $NAMESPACE_CONTROLLER$;
+
+use $NAMESPACE_REQUEST$\CreateUserRequest;
+use $NAMESPACE_REQUEST$\UpdateUserRequest;
+use $NAMESPACE_REPOSITORY$\UserRepository;
+use $NAMESPACE_CONTROLLER$\AppBaseController;
+use Illuminate\Http\Request;
+use Flash;
+use Response;
+
+class UserController extends AppBaseController
+{
+    /** @var $userRepository UserRepository */
+    private $userRepository;
+
+    public function __construct(UserRepository $userRepo)
+    {
+        $this->userRepository = $userRepo;
+    }
+
+    /**
+     * Display a listing of the User.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function index(Request $request)
+    {
+        $users = $this->userRepository->all();
+
+        return view('users.index')->with('users', $users);
+    }
+
+    /**
+     * Show the form for creating a new User.
+     *
+     * @return Response
+     */
+    public function create()
+    {
+        return view('users.create');
+    }
+
+    /**
+     * Store a newly created User in storage.
+     *
+     * @param CreateUserRequest $request
+     *
+     * @return Response
+     */
+    public function store(CreateUserRequest $request)
+    {
+        $input = $request->all();
+
+        $user = $this->userRepository->create($input);
+
+        Flash::success('User saved successfully.');
+
+        return redirect(route('users.index'));
+    }
+
+    /**
+     * Display the specified User.
+     *
+     * @param int $id
+     *
+     * @return Response
+     */
+    public function show($id)
+    {
+        $user = $this->userRepository->find($id);
+
+        if (empty($user)) {
+            Flash::error('User not found');
+
+            return redirect(route('users.index'));
+        }
+
+        return view('users.show')->with('user', $user);
+    }
+
+    /**
+     * Show the form for editing the specified User.
+     *
+     * @param int $id
+     *
+     * @return Response
+     */
+    public function edit($id)
+    {
+        $user = $this->userRepository->find($id);
+
+        if (empty($user)) {
+            Flash::error('User not found');
+
+            return redirect(route('users.index'));
+        }
+
+        return view('users.edit')->with('user', $user);
+    }
+
+    /**
+     * Update the specified User in storage.
+     *
+     * @param int $id
+     * @param UpdateUserRequest $request
+     *
+     * @return Response
+     */
+    public function update($id, UpdateUserRequest $request)
+    {
+        $user = $this->userRepository->find($id);
+
+        if (empty($user)) {
+            Flash::error('User not found');
+
+            return redirect(route('users.index'));
+        }
+
+        $user = $this->userRepository->update($request->all(), $id);
+
+        Flash::success('User updated successfully.');
+
+        return redirect(route('users.index'));
+    }
+
+    /**
+     * Remove the specified User from storage.
+     *
+     * @param int $id
+     *
+     * @throws \Exception
+     *
+     * @return Response
+     */
+    public function destroy($id)
+    {
+        $user = $this->userRepository->find($id);
+
+        if (empty($user)) {
+            Flash::error('User not found');
+
+            return redirect(route('users.index'));
+        }
+
+        $this->userRepository->delete($id);
+
+        Flash::success('User deleted successfully.');
+
+        return redirect(route('users.index'));
+    }
+}

--- a/templates/user/user_controller.stub
+++ b/templates/user/user_controller.stub
@@ -9,6 +9,7 @@ use $NAMESPACE_CONTROLLER$\AppBaseController;
 use Illuminate\Http\Request;
 use Flash;
 use Response;
+use Hash;
 
 class UserController extends AppBaseController
 {
@@ -54,7 +55,7 @@ class UserController extends AppBaseController
     public function store(CreateUserRequest $request)
     {
         $input = $request->all();
-
+        $input['password'] = Hash::make($input['password']);
         $user = $this->userRepository->create($input);
 
         Flash::success('User saved successfully.');
@@ -119,8 +120,13 @@ class UserController extends AppBaseController
 
             return redirect(route('users.index'));
         }
-
-        $user = $this->userRepository->update($request->all(), $id);
+        $input =  $request->all();
+        if (!empty($input['password'])) {
+            $input['password'] = Hash::make($input['password']);
+        } else {
+            unset($input['password']);
+        }
+        $user = $this->userRepository->update($input, $id);
 
         Flash::success('User updated successfully.');
 

--- a/templates/user/user_controller_without_repository.stub
+++ b/templates/user/user_controller_without_repository.stub
@@ -9,7 +9,7 @@ use Illuminate\Http\Request;
 use Flash;
 use Response;
 use Hash;
-use App\User;
+use $NAMESPACE_USER$;
 class UserController extends AppBaseController
 {
     /**

--- a/templates/user/user_controller_without_repository.stub
+++ b/templates/user/user_controller_without_repository.stub
@@ -4,7 +4,6 @@ namespace $NAMESPACE_CONTROLLER$;
 
 use $NAMESPACE_REQUEST$\CreateUserRequest;
 use $NAMESPACE_REQUEST$\UpdateUserRequest;
-use $NAMESPACE_REPOSITORY$\UserRepository;
 use $NAMESPACE_CONTROLLER$\AppBaseController;
 use Illuminate\Http\Request;
 use Flash;

--- a/templates/user/user_controller_without_repository.stub
+++ b/templates/user/user_controller_without_repository.stub
@@ -1,0 +1,161 @@
+<?php
+
+namespace $NAMESPACE_CONTROLLER$;
+
+use $NAMESPACE_REQUEST$\CreateUserRequest;
+use $NAMESPACE_REQUEST$\UpdateUserRequest;
+use $NAMESPACE_REPOSITORY$\UserRepository;
+use $NAMESPACE_CONTROLLER$\AppBaseController;
+use Illuminate\Http\Request;
+use Flash;
+use Response;
+use Hash;
+use App\User;
+class UserController extends AppBaseController
+{
+    /**
+     * Display a listing of the User.
+     *
+     * @param Request $request
+     *
+     * @return Response
+     */
+    public function index(Request $request)
+    {
+        /** @var User $users */
+        $users = User::all();
+
+        return view('users.index')
+            ->with('users', $users);
+    }
+
+    /**
+     * Show the form for creating a new User.
+     *
+     * @return Response
+     */
+    public function create()
+    {
+        return view('users.create');
+    }
+
+    /**
+     * Store a newly created User in storage.
+     *
+     * @param CreateUserRequest $request
+     *
+     * @return Response
+     */
+    public function store(CreateUserRequest $request)
+    {
+        $input = $request->all();
+        $input['password'] = Hash::make($input['password']);
+        /** @var User $user */
+        $user = User::create($input);
+
+        Flash::success('User saved successfully.');
+
+        return redirect(route('users.index'));
+    }
+
+    /**
+     * Display the specified User.
+     *
+     * @param int $id
+     *
+     * @return Response
+     */
+    public function show($id)
+    {
+        /** @var User $user */
+        $user = User::find($id);
+
+        if (empty($user)) {
+            Flash::error('User not found');
+
+            return redirect(route('users.index'));
+        }
+
+        return view('users.show')->with('user', $user);
+    }
+
+    /**
+     * Show the form for editing the specified User.
+     *
+     * @param int $id
+     *
+     * @return Response
+     */
+    public function edit($id)
+    {
+        /** @var User $user */
+        $user = User::find($id);
+
+        if (empty($user)) {
+            Flash::error('User not found');
+
+            return redirect(route('users.index'));
+        }
+
+        return view('users.edit')->with('user', $user);
+    }
+
+    /**
+     * Update the specified User in storage.
+     *
+     * @param int $id
+     * @param UpdateUserRequest $request
+     *
+     * @return Response
+     */
+    public function update($id, UpdateUserRequest $request)
+    {
+        /** @var User $user */
+        $user = User::find($id);
+
+        if (empty($user)) {
+            Flash::error('User not found');
+
+            return redirect(route('users.index'));
+        }
+        $input =  $request->all();
+        if (!empty($input['password'])) {
+            $input['password'] = Hash::make($input['password']);
+        } else {
+            unset($input['password']);
+        }
+        $user->fill($input);
+        $user->save();
+
+        Flash::success('User updated successfully.');
+
+        return redirect(route('users.index'));
+    }
+
+    /**
+     * Remove the specified User from storage.
+     *
+     * @param int $id
+     *
+     * @throws \Exception
+     *
+     * @return Response
+     */
+    public function destroy($id)
+    {
+        /** @var User $user */
+        $user = User::find($id);
+
+        if (empty($user)) {
+            Flash::error('User not found');
+
+            return redirect(route('users.index'));
+        }
+
+        $user->delete();
+
+        Flash::success('User deleted successfully.');
+
+        return redirect(route('users.index'));
+    }
+}

--- a/templates/user/user_repository.stub
+++ b/templates/user/user_repository.stub
@@ -1,0 +1,42 @@
+<?php
+
+namespace $NAMESPACE_REPOSITORY$;
+
+use App\User;
+use $NAMESPACE_REPOSITORY$\BaseRepository;
+
+/**
+ * Class UserRepository
+ * @package $NAMESPACE_REPOSITORY$
+ * @version October 8, 2019, 5:51 am UTC
+*/
+
+class UserRepository extends BaseRepository
+{
+    /**
+     * @var array
+     */
+    protected $fieldSearchable = [
+        'name',
+        'email',
+        'password'
+    ];
+
+    /**
+     * Return searchable fields
+     *
+     * @return array
+     */
+    public function getFieldsSearchable()
+    {
+        return $this->fieldSearchable;
+    }
+
+    /**
+     * Configure the Model
+     **/
+    public function model()
+    {
+        return User::class;
+    }
+}

--- a/templates/user/user_repository.stub
+++ b/templates/user/user_repository.stub
@@ -8,7 +8,6 @@ use $NAMESPACE_REPOSITORY$\BaseRepository;
 /**
  * Class UserRepository
  * @package $NAMESPACE_REPOSITORY$
- * @version October 8, 2019, 5:51 am UTC
 */
 
 class UserRepository extends BaseRepository

--- a/templates/user/user_repository.stub
+++ b/templates/user/user_repository.stub
@@ -2,7 +2,7 @@
 
 namespace $NAMESPACE_REPOSITORY$;
 
-use App\User;
+use $NAMESPACE_USER$;
 use $NAMESPACE_REPOSITORY$\BaseRepository;
 
 /**


### PR DESCRIPTION
### What Implemented? 

- User CRUD publish with default field which are provided by Laravel framework.
-  Publish User CRUD via using `php artisan infyom.publish:user` command

**following files generated by this command**

1. Controller
2. Repository
3. Views
4. Route
5. Menu
6. Requests

before fire this command need to complete installation steps and publish layouts

after publish user CRUD. 

for more detail about issue.
How to integrate Users with scaffold? [#666](https://github.com/InfyOmLabs/laravel-generator/issues/666)

#### How to Test?
Add this package in. composer and update it. do all step of infyom pkg installations. 
```
 "infyomlabs/laravel-generator": "dev-issue-666-user-publish",
  "infyomlabs/adminlte-templates": "dev-issue-666-user-crud-template",
```
then after run command   `php artisan infyom.publish:user`
Check admin panel. you can see user menu and test it.