### PR TITLE
#168 Multi Database (connection) support added

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -270,6 +270,7 @@ class BaseCommand extends Command
             ['factory', null, InputOption::VALUE_NONE, 'To generate factory'],
             ['seeder', null, InputOption::VALUE_NONE, 'To generate seeder'],
             ['repositoryPattern', null, InputOption::VALUE_REQUIRED, 'Repository Pattern'],
+            ['connection', null, InputOption::VALUE_REQUIRED, 'Specify connection name'],
         ];
     }
 

--- a/src/Common/CommandData.php
+++ b/src/Common/CommandData.php
@@ -274,7 +274,7 @@ class CommandData
             $ignoredFields = [];
         }
 
-        $tableFieldsGenerator = new TableFieldsGenerator($tableName, $ignoredFields);
+        $tableFieldsGenerator = new TableFieldsGenerator($tableName, $ignoredFields, $this->config->connection);
         $tableFieldsGenerator->prepareFieldsFromTable();
         $tableFieldsGenerator->prepareRelations();
 

--- a/src/Common/GeneratorConfig.php
+++ b/src/Common/GeneratorConfig.php
@@ -60,6 +60,8 @@ class GeneratorConfig
     public $mHuman;
     public $mHumanPlural;
 
+    public $connection = '';
+
     /* Generator Options */
     public $options;
 
@@ -89,6 +91,7 @@ class GeneratorConfig
         'factory',
         'seeder',
         'repositoryPattern',
+        'connection',
     ];
 
     public $tableName;
@@ -260,6 +263,13 @@ class GeneratorConfig
         $commandData->addDynamicVariable('$MODEL_NAME_HUMAN$', $this->mHuman);
         $commandData->addDynamicVariable('$MODEL_NAME_PLURAL_HUMAN$', $this->mHumanPlural);
         $commandData->addDynamicVariable('$FILES$', '');
+
+        $connectionText = '';
+        if ($connection = $this->getOption('connection')) {
+            $this->connection = $connection;
+            $connectionText = infy_tab(4).'public $connection = "'.$connection.'";';
+        }
+        $commandData->addDynamicVariable('$CONNECTION$', $connectionText);
 
         if (!empty($this->prefixes['route'])) {
             $commandData->addDynamicVariable('$ROUTE_NAMED_PREFIX$', $this->prefixes['route'].'.');

--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -89,7 +89,7 @@ class TableFieldsGenerator
             }
         }
 
-        $this->primaryKey = static::getPrimaryKeyOfTable($tableName);
+        $this->primaryKey = $this->getPrimaryKeyOfTable($tableName);
         $this->timestamps = static::getTimestampFieldNames();
         $this->defaultSearchable = config('infyom.laravel_generator.options.tables_searchable_default', false);
     }
@@ -170,10 +170,9 @@ class TableFieldsGenerator
      *
      * @return string|null The column name of the (simple) primary key
      */
-    public static function getPrimaryKeyOfTable($tableName)
+    public function getPrimaryKeyOfTable($tableName)
     {
-        $schema = DB::getDoctrineSchemaManager();
-        $column = $schema->listTableDetails($tableName)->getPrimaryKey();
+        $column = $this->schemaManager->listTableDetails($tableName)->getPrimaryKey();
 
         return $column ? $column->getColumns()[0] : '';
     }

--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -56,12 +56,17 @@ class TableFieldsGenerator
     /** @var array */
     public $ignoredFields;
 
-    public function __construct($tableName, $ignoredFields)
+    public function __construct($tableName, $ignoredFields, $connection = '')
     {
         $this->tableName = $tableName;
         $this->ignoredFields = $ignoredFields;
 
-        $this->schemaManager = DB::getDoctrineSchemaManager();
+        if (!empty($connection)) {
+            $this->schemaManager = DB::connection($connection)->getDoctrineSchemaManager();
+        } else {
+            $this->schemaManager = DB::getDoctrineSchemaManager();
+        }
+
         $platform = $this->schemaManager->getDatabasePlatform();
         $defaultMappings = [
             'enum' => 'string',

--- a/templates/model/model.stub
+++ b/templates/model/model.stub
@@ -11,6 +11,7 @@ $SOFT_DELETE$
     public $table = '$TABLE_NAME$';
     $TIMESTAMPS$
 $SOFT_DELETE_DATES$
+$CONNECTION$
 $PRIMARY$
     public $fillable = [
         $FIELDS$


### PR DESCRIPTION
#168 


### Added
- when user has more then one DB (connection 1 and connection2), if connection 1 is set into env and user want to create CRUD from connection2, so he does not need to change env just use option `--connection=connection2`

e.g `php artisan infyom:scaffold --fromTable --tableName=users --connection=connectionName`
