### PR TITLE
#768 Added prettus/l5-repository back as a require dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     ],
     "require": {
         "php": ">=7.2",
+        "prettus/l5-repository": "^2.6",
         "illuminate/support": "^6.0.0",
         "laracasts/flash": "~3.0"
     },
@@ -51,5 +52,5 @@
                 "\\InfyOm\\Generator\\InfyOmGeneratorServiceProvider"
             ]
         }
-    }    
+    }
 }


### PR DESCRIPTION
Regarding to the issue #768 
Added the `prettus/l5-repository` back.