### PR TITLE
Don't repeat menus and routes

### DIFF
--- a/src/Generators/API/APIRoutesGenerator.php
+++ b/src/Generators/API/APIRoutesGenerator.php
@@ -39,6 +39,12 @@ class APIRoutesGenerator extends BaseGenerator
     public function generate()
     {
         $this->routeContents .= "\n\n".$this->routesTemplate;
+        $existingRouteContents = file_get_contents($this->path);
+        if (Str::contains($existingRouteContents, "Route::resource('".$this->commandData->config->mSnakePlural."',")) {
+            $this->commandData->commandObj->info('Menu '.$this->commandData->config->mPlural.'is already exists, Skipping Adjustment.');
+
+            return;
+        }
 
         file_put_contents($this->path, $this->routeContents);
 

--- a/src/Generators/Scaffold/MenuGenerator.php
+++ b/src/Generators/Scaffold/MenuGenerator.php
@@ -43,6 +43,12 @@ class MenuGenerator extends BaseGenerator
     public function generate()
     {
         $this->menuContents .= $this->menuTemplate.infy_nl();
+        $existingMenuContents = file_get_contents($this->path);
+        if (Str::contains($existingMenuContents, "<span>".$this->commandData->config->mPlural."</span>")) {
+            $this->commandData->commandObj->info('Menu '.$this->commandData->config->mPlural.' is already exists, Skipping Adjustment.');
+
+            return;
+        }
 
         file_put_contents($this->path, $this->menuContents);
         $this->commandData->commandComment("\n".$this->commandData->config->mCamelPlural.' menu added.');

--- a/src/Generators/Scaffold/MenuGenerator.php
+++ b/src/Generators/Scaffold/MenuGenerator.php
@@ -44,7 +44,7 @@ class MenuGenerator extends BaseGenerator
     {
         $this->menuContents .= $this->menuTemplate.infy_nl();
         $existingMenuContents = file_get_contents($this->path);
-        if (Str::contains($existingMenuContents, "<span>".$this->commandData->config->mPlural."</span>")) {
+        if (Str::contains($existingMenuContents, '<span>'.$this->commandData->config->mPlural.'</span>')) {
             $this->commandData->commandObj->info('Menu '.$this->commandData->config->mPlural.' is already exists, Skipping Adjustment.');
 
             return;

--- a/src/Generators/Scaffold/MenuGenerator.php
+++ b/src/Generators/Scaffold/MenuGenerator.php
@@ -44,8 +44,8 @@ class MenuGenerator extends BaseGenerator
     {
         $this->menuContents .= $this->menuTemplate.infy_nl();
         $existingMenuContents = file_get_contents($this->path);
-        if (Str::contains($existingMenuContents, '<span>'.$this->commandData->config->mPlural.'</span>')) {
-            $this->commandData->commandObj->info('Menu '.$this->commandData->config->mPlural.' is already exists, Skipping Adjustment.');
+        if (Str::contains($existingMenuContents, '<span>'.$this->commandData->config->mHumanPlural.'</span>')) {
+            $this->commandData->commandObj->info('Menu '.$this->commandData->config->mHumanPlural.' is already exists, Skipping Adjustment.');
 
             return;
         }

--- a/src/Generators/Scaffold/RoutesGenerator.php
+++ b/src/Generators/Scaffold/RoutesGenerator.php
@@ -35,6 +35,12 @@ class RoutesGenerator
     public function generate()
     {
         $this->routeContents .= "\n\n".$this->routesTemplate;
+        $existingRouteContents = file_get_contents($this->path);
+        if (Str::contains($existingRouteContents, "Route::resource('".$this->commandData->config->mSnakePlural."',")) {
+            $this->commandData->commandObj->info('Route '.$this->commandData->config->mPlural.' is already exists, Skipping Adjustment.');
+
+            return;
+        }
 
         file_put_contents($this->path, $this->routeContents);
         $this->commandData->commandComment("\n".$this->commandData->config->mCamelPlural.' routes added.');


### PR DESCRIPTION
### Issue
- while executing scaffold, api command twice for same model, menus and routes are duplicating.

### Fixed
- menus and routes are not generating twice for same model into `menu.blade.php`, `api.php` and `web.php`
