### PR TITLE
Send only success message on record deletion

### DIFF
--- a/templates/api/controller/api_controller.stub
+++ b/templates/api/controller/api_controller.stub
@@ -85,6 +85,6 @@ class $MODEL_NAME$APIController extends AppBaseController
 
         $$MODEL_NAME_CAMEL$->delete();
 
-        return $this->sendResponse($id, '$MODEL_NAME_HUMAN$ deleted successfully');
+        return $this->sendSuccess('$MODEL_NAME_HUMAN$ deleted successfully');
     }
 }

--- a/templates/api/controller/model_api_controller.stub
+++ b/templates/api/controller/model_api_controller.stub
@@ -81,6 +81,6 @@ class $MODEL_NAME$APIController extends AppBaseController
 
         $$MODEL_NAME_CAMEL$->delete();
 
-        return $this->sendResponse($id, '$MODEL_NAME_HUMAN$ deleted successfully');
+        return $this->sendSuccess('$MODEL_NAME_HUMAN$ deleted successfully');
     }
 }

--- a/templates/app_base_controller.stub
+++ b/templates/app_base_controller.stub
@@ -27,4 +27,12 @@ class AppBaseController extends Controller
     {
         return Response::json(ResponseUtil::makeError($error), $code);
     }
+
+    public function sendSuccess($message)
+    {
+        return Response::json([
+            'success' => true,
+            'message' => $message
+        ], 200);
+    }
 }


### PR DESCRIPTION
How to test:

Run `php artisan infyom:publish` and replace just `AppBaseController.php`, now create any API using command

- In current version when we delete record its return message like 


```
{
  data : 1,
  success: true,
  message: Model deleted successfully.
}
```
by making this changing it should return :

```
{
  success: true,
  message: Model deleted successfully.
}
```