### PR TITLE
Fix rule validations being populated after they are already required by swagger model doc

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -55,6 +55,7 @@ class ModelGenerator extends BaseGenerator
 
     private function fillTemplate($templateData)
     {
+        $rules = $this->generateRules();
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
 
         $templateData = $this->fillSoftDeletes($templateData);
@@ -81,7 +82,7 @@ class ModelGenerator extends BaseGenerator
 
         $templateData = str_replace('$FIELDS$', implode(','.infy_nl_tab(1, 2), $fillables), $templateData);
 
-        $templateData = str_replace('$RULES$', implode(','.infy_nl_tab(1, 2), $this->generateRules()), $templateData);
+        $templateData = str_replace('$RULES$', implode(','.infy_nl_tab(1, 2), $rules), $templateData);
 
         $templateData = str_replace('$CAST$', implode(','.infy_nl_tab(1, 2), $this->generateCasts()), $templateData);
 


### PR DESCRIPTION
This should work around an edge case where the swagger documentation code is attempting to determine if a field is required before the validation rules have been generated for that particular field.

The symptom being that "$REQUIRED_FIELDS$" is always empty when generating a model - the data for this property is created at the generateSwagger method which sources from the generateRequiredFields method.

The generateRequiredFields method iterates through the fields and checks to see if any of the validations are required - the problem being that due to the ordering of calls in fillTemplate, the validations have not yet been determined and thus it will always fail.