### PR TITLE
fix: Swagger model property separator appearing on separate line

### DIFF
--- a/src/Generators/SwaggerGenerator.php
+++ b/src/Generators/SwaggerGenerator.php
@@ -143,6 +143,7 @@ class SwaggerGenerator
                 $format = ",\n *          format=\"".$format.'"';
             }
             $propertyTemplate = str_replace('$FIELD_FORMAT$', $format, $propertyTemplate);
+            $propertyTemplate = rtrim($propertyTemplate);
             $templates[] = $propertyTemplate;
         }
 


### PR DESCRIPTION
The current templates from InfyOmLabs/swagger-generator don't have an
EOL in the file whereas any normal unix editor will add this by default.

This trims trailing whitespace/line ends when building the list of
property annotations for a model and avoids the separator appearing on a
separate line for custom templates.