### PR TITLE
fix: Prevent spurious line endings when including partial stubs

### DIFF
--- a/src/Common/GeneratorFieldRelation.php
+++ b/src/Common/GeneratorFieldRelation.php
@@ -82,7 +82,7 @@ class GeneratorFieldRelation
         $inputs = $this->inputs;
         $modelName = array_shift($inputs);
 
-        $template = get_template('model.relationship', 'laravel-generator');
+        $template = get_template('model.relationship', 'laravel-generator', true);
 
         $template = str_replace('$RELATIONSHIP_CLASS$', $relationClass, $template);
         $template = str_replace('$FUNCTION_NAME$', $functionName, $template);

--- a/src/Generators/API/APIControllerGenerator.php
+++ b/src/Generators/API/APIControllerGenerator.php
@@ -61,7 +61,7 @@ class APIControllerGenerator extends BaseGenerator
 
         foreach ($methods as $method) {
             $key = '$DOC_'.strtoupper($method).'$';
-            $docTemplate = get_template($templatePrefix.'.'.$method, $templateType);
+            $docTemplate = get_template($templatePrefix.'.'.$method, $templateType, true);
             $docTemplate = fill_template($this->commandData->dynamicVars, $docTemplate);
             $templateData = str_replace($key, $docTemplate, $templateData);
         }

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -127,7 +127,7 @@ class ModelGenerator extends BaseGenerator
             $templateData = $this->generateSwagger($templateData);
         }
 
-        $docsTemplate = get_template('docs.model', 'laravel-generator');
+        $docsTemplate = get_template('docs.model', 'laravel-generator', true);
         $docsTemplate = fill_template($this->commandData->dynamicVars, $docsTemplate);
 
         $fillables = '';
@@ -199,7 +199,7 @@ class ModelGenerator extends BaseGenerator
     {
         $fieldTypes = SwaggerGenerator::generateTypes($this->commandData->fields);
 
-        $template = get_template('model_docs.model', 'swagger-generator');
+        $template = get_template('model_docs.model', 'swagger-generator', true);
 
         $template = fill_template($this->commandData->dynamicVars, $template);
 
@@ -209,7 +209,7 @@ class ModelGenerator extends BaseGenerator
             $template
         );
 
-        $propertyTemplate = get_template('model_docs.property', 'swagger-generator');
+        $propertyTemplate = get_template('model_docs.property', 'swagger-generator', true);
 
         $properties = SwaggerGenerator::preparePropertyFields($propertyTemplate, $fieldTypes);
 

--- a/src/Generators/RepositoryGenerator.php
+++ b/src/Generators/RepositoryGenerator.php
@@ -39,7 +39,7 @@ class RepositoryGenerator extends BaseGenerator
 
         $templateData = str_replace('$FIELDS$', implode(','.infy_nl_tab(1, 2), $searchables), $templateData);
 
-        $docsTemplate = get_template('docs.repository', 'laravel-generator');
+        $docsTemplate = get_template('docs.repository', 'laravel-generator', true);
         $docsTemplate = fill_template($this->commandData->dynamicVars, $docsTemplate);
         $docsTemplate = str_replace('$GENERATE_DATE$', date('F j, Y, g:i a T'), $docsTemplate);
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -110,7 +110,7 @@ if (!function_exists('get_template')) {
      *
      * @param string $templateName
      * @param string $templateType
-     * @param bool   $stripEndOfline  Strip the end of line from the returned template file
+     * @param bool   $stripEndOfline Strip the end of line from the returned template file
      *
      * @return string
      */

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -110,14 +110,31 @@ if (!function_exists('get_template')) {
      *
      * @param string $templateName
      * @param string $templateType
+     * @param bool $stripEndOfline  Strip the end of line from the returned template file
      *
      * @return string
      */
-    function get_template($templateName, $templateType)
+    function get_template($templateName, $templateType, $stripEndOfLine = false)
     {
         $path = get_template_file_path($templateName, $templateType);
 
-        return file_get_contents($path);
+        $content = file_get_contents($path);
+
+        /**
+         * Strip the last line ending from the template.
+         *
+         * This is needed for partial templates such as documentation sections
+         * which are then included inside a larger template.
+         *
+         * Any partial template file edited on a unix-like system will have an
+         * EOL that will cause an unexpected extra line end when combined with
+         * the main template.
+         */
+        if ($stripEndOfLine) {
+            return rtrim($content, "\r\n");
+        }
+
+        return $content;
     }
 }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -110,7 +110,7 @@ if (!function_exists('get_template')) {
      *
      * @param string $templateName
      * @param string $templateType
-     * @param bool $stripEndOfline  Strip the end of line from the returned template file
+     * @param bool   $stripEndOfline  Strip the end of line from the returned template file
      *
      * @return string
      */


### PR DESCRIPTION
Any partial template stub (such as a documentation section) edited on a unix-like system will generally have an EOL at the end of the file that will cause an unexpected extra line end when combined with the main template unless we remove it.

To replicate the issue - create a sample application and publish the templates (in my test case, also including the swagger documentation as well) then generate some code:

For example:
`./artisan infyom:api PricebookItem --fromTable --tableName=pricebook_item && git add .`

Re-write the templates to include an EOL by default as per unix standard and then regenerate the code via artisan:
```
find resoures/templates-directory | while read f; do tail -n1 $f | read -r _ || echo >> $f; done
./artisan infyom:api PricebookItem --fromTable --tableName=pricebook_item
```

With the fix from this pull request the generated code should be identical, the exception being any existing templates that were already in unix format which will have already generated a spurious line ending (docs/repository.stub being an example).

Without this fix the existing code will generate a large number of extra line endings:
```diff
akeynes@fudd:~/git/pos-backend$ git diff app
diff --git a/app/Http/Controllers/API/PricebookItemAPIController.php b/app/Http/Controllers/API/PricebookItemAPIController.php
index 6573122..6fef445 100644
--- a/app/Http/Controllers/API/PricebookItemAPIController.php
+++ b/app/Http/Controllers/API/PricebookItemAPIController.php
@@ -32,6 +32,7 @@ class PricebookItemAPIController extends AppBaseController
      * @param Request $request
      * @return Response
      */
+
     public function index(Request $request)
     {
         $pricebookItems = $this->pricebookItemRepository->all(
@@ -51,6 +52,7 @@ class PricebookItemAPIController extends AppBaseController
      *
      * @return Response
      */
+
     public function store(CreatePricebookItemAPIRequest $request)
     {
         $input = $request->all();
@@ -68,6 +70,7 @@ class PricebookItemAPIController extends AppBaseController
      *
      * @return Response
      */
+
     public function show($id)
     {
         /** @var PricebookItem $pricebookItem */
@@ -89,6 +92,7 @@ class PricebookItemAPIController extends AppBaseController
      *
      * @return Response
      */
+
     public function update($id, UpdatePricebookItemAPIRequest $request)
     {
         $input = $request->all();
@@ -115,6 +119,7 @@ class PricebookItemAPIController extends AppBaseController
      *
      * @return Response
      */
+
     public function destroy($id)
     {
         /** @var PricebookItem $pricebookItem */
diff --git a/app/Models/PricebookItem.php b/app/Models/PricebookItem.php
index 72cd3a4..16e5cfe 100644
--- a/app/Models/PricebookItem.php
+++ b/app/Models/PricebookItem.php
@@ -7,7 +7,7 @@ use Eloquent as Model;
 /**
  * Class PricebookItem
  * @package App\Models
- * @version May 15, 2020, 7:03 am UTC
+ * @version May 15, 2020, 7:04 am UTC
  *
  * @property \App\Models\Pricebook $pricebook
  * @property \App\Models\ProductChannel $productChannel
@@ -21,6 +21,7 @@ use Eloquent as Model;
  * @property boolean $in_stock
  * @property string|\Carbon\Carbon $modified_at
  */
+
 class PricebookItem extends Model
 {
 
@@ -78,6 +79,7 @@ class PricebookItem extends Model
         return $this->belongsTo(\App\Models\Pricebook::class, 'pricebook_id');
     }
 
+
     /**
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      **/
@@ -86,6 +88,7 @@ class PricebookItem extends Model
         return $this->belongsTo(\App\Models\ProductChannel::class, 'product_channel_id');
     }
 
+
     /**
      * @return \Illuminate\Database\Eloquent\Relations\HasMany
      **/
@@ -93,4 +96,5 @@ class PricebookItem extends Model
     {
         return $this->hasMany(\App\Models\CartItem::class, 'pricebook_item_id');
     }
+
 }
diff --git a/app/Repositories/PricebookItemRepository.php b/app/Repositories/PricebookItemRepository.php
index ff8da01..67ac8b7 100644
--- a/app/Repositories/PricebookItemRepository.php
+++ b/app/Repositories/PricebookItemRepository.php
@@ -8,7 +8,7 @@ use App\Repositories\BaseRepository;
 /**
  * Class PricebookItemRepository
  * @package App\Repositories
- * @version May 15, 2020, 7:03 am UTC
+ * @version May 15, 2020, 7:04 am UTC
 */
 
 class PricebookItemRepository extends BaseRepository
```