### PR TITLE
Fix decimal fields being generated as floats inside model casts

### DIFF
--- a/src/Common/GeneratorField.php
+++ b/src/Common/GeneratorField.php
@@ -31,6 +31,9 @@ class GeneratorField
     public $inView = true;
     public $isNotNull = false;
 
+    /** @var int */
+    public $numberDecimalPoints = 2;
+
     /**
      * @param Column $column
      * @param $dbInput

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -333,8 +333,10 @@ class ModelGenerator extends BaseGenerator
                 case 'double':
                     $rule .= "'double'";
                     break;
-                case 'float':
                 case 'decimal':
+                    $rule .= sprintf("'decimal:%d'", $field->numberDecimalPoints);
+                    break;
+                case 'float':
                     $rule .= "'float'";
                     break;
                 case 'boolean':

--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -278,6 +278,10 @@ class TableFieldsGenerator
         $field->parseDBType($dbType.','.$column->getPrecision().','.$column->getScale());
         $field->htmlType = 'number';
 
+        if ($dbType === 'decimal') {
+            $field->numberDecimalPoints = $column->getScale();
+        }
+
         return $this->checkForPrimary($field);
     }
 


### PR DESCRIPTION
Currently decimal fields are populated as floats inside generated model casts which is not ideal as the two are not equivalent.

This casts them to decimal (defaulting to two decimal places) and should automatically determine the correct number of decimal places if sourcing from a database.

Note that the laravel 'decimal' cast actually returns a string via number_format as there is no native PHP decimal type - usage of bcmath, a decimal or money class is probably the desired end state for most users however that is outside the scope of this project.