### PR TITLE
Add basic attribute validation when generating from a database table

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -18,6 +18,7 @@ class ModelGenerator extends BaseGenerator
     protected $excluded_fields = [
         'created_at',
         'updated_at',
+        'deleted_at',
     ];
 
     /** @var CommandData */
@@ -266,7 +267,7 @@ class ModelGenerator extends BaseGenerator
     private function generateRules()
     {
         $dont_require_fields = config('infyom.laravel_generator.options.hidden_fields', [])
-                + config('infyom.laravel_generator.options.excluded_fields', []);
+                + config('infyom.laravel_generator.options.excluded_fields', $this->excluded_fields);
 
         $rules = [];
 

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -305,7 +305,7 @@ class ModelGenerator extends BaseGenerator
                             // Enforce a maximum string length if possible.
                             foreach ($dbOptions as $key => $value) {
                                 if (preg_match('/string,(\d+)/', $value, $matches)) {
-                                    $rule[] = 'max:' . $matches[1];
+                                    $rule[] = 'max:'.$matches[1];
                                 }
                             }
                             break;

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -295,6 +295,7 @@ class ModelGenerator extends BaseGenerator
                             $rule[] = 'boolean';
                             break;
                         case 'float':
+                        case 'double':
                         case 'decimal':
                             $rule[] = 'numeric';
                             break;

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -271,9 +271,51 @@ class ModelGenerator extends BaseGenerator
         $rules = [];
 
         foreach ($this->commandData->fields as $field) {
-            if (!$field->isPrimary && $field->isNotNull && empty($field->validations) &&
-                !in_array($field->name, $dont_require_fields)) {
-                $field->validations = 'required';
+            if (!$field->isPrimary && !in_array($field->name, $dont_require_fields)) {
+                if ($field->isNotNull && empty($field->validations)) {
+                    $field->validations = 'required';
+                }
+
+                /**
+                 * Generate some sane defaults based on the field type if we
+                 * are generating from a database table.
+                 */
+                if ($this->commandData->getOption('fromTable')) {
+                    $rule = empty($field->validations) ? [] : explode('|', $field->validations);
+                    $dbOptions = explode(':', $field->dbInput);
+
+                    if (in_array('nullable', $dbOptions)) {
+                        $rule[] = 'nullable';
+                    }
+
+                    switch ($field->fieldType) {
+                        case 'integer':
+                            $rule[] = 'integer';
+                            break;
+                        case 'boolean':
+                            $rule[] = 'boolean';
+                            break;
+                        case 'float':
+                        case 'decimal':
+                            $rule[] = 'numeric';
+                            break;
+                        case 'string':
+                            $rule[] = 'string';
+
+                            // Enforce a maximum string length if possible.
+                            foreach ($dbOptions as $key => $value) {
+                                if (preg_match('/string,(\d+)/', $value, $matches)) {
+                                    $rule[] = 'max:' . $matches[1];
+                                }
+                            }
+                            break;
+                        case 'text':
+                            $rule[] = 'string';
+                            break;
+                    }
+
+                    $field->validations = implode('|', $rule);
+                }
             }
 
             if (!empty($field->validations)) {

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -282,9 +282,8 @@ class ModelGenerator extends BaseGenerator
                  */
                 if ($this->commandData->getOption('fromTable')) {
                     $rule = empty($field->validations) ? [] : explode('|', $field->validations);
-                    $dbOptions = explode(':', $field->dbInput);
 
-                    if (in_array('nullable', $dbOptions)) {
+                    if (!$field->isNotNull) {
                         $rule[] = 'nullable';
                     }
 
@@ -303,7 +302,7 @@ class ModelGenerator extends BaseGenerator
                             $rule[] = 'string';
 
                             // Enforce a maximum string length if possible.
-                            foreach ($dbOptions as $key => $value) {
+                            foreach (explode(':', $field->dbInput) as $key => $value) {
                                 if (preg_match('/string,(\d+)/', $value, $matches)) {
                                     $rule[] = 'max:'.$matches[1];
                                 }


### PR DESCRIPTION
These are generated based on the column data as reported from the database.

For instance, assuming an example database structure as follows:

```sql
CREATE TABLE `country` (
  `code` char(2) NOT NULL,
  `name` varchar(255) NOT NULL,
  `continent_name` varchar(255) DEFAULT NULL,
  `upstream_id` int(11) DEFAULT NULL,
  PRIMARY KEY (`code`)
)
```

With this commit in place we will now automatically generate model rules as follows:

```diff
     public static $rules = [
-        'name' => 'required'
+        'name' => 'required|string|max:255',
+        'continent_name' => 'nullable|string|max:255',
+        'upstream_id' => 'nullable|integer'
     ];
```

Note that this only matches the most common column types - any others will simply generate no extra rules as per the original behaviour.