### PR TITLE
Expose 'readOnly' and 'nullable' when building swagger model properties

### DIFF
--- a/src/Generators/SwaggerGenerator.php
+++ b/src/Generators/SwaggerGenerator.php
@@ -28,9 +28,9 @@ class SwaggerGenerator
 
             if (!empty($fieldType)) {
                 $fieldType = [
-                    'name'   => $field->name,
-                    'type'   => $fieldType,
-                    'format' => $fieldFormat,
+                    'name'     => $field->name,
+                    'type'     => $fieldType,
+                    'format'   => $fieldFormat,
                     'nullable' => !$field->isNotNull,
                     'readOnly' => !$field->isFillable,
                 ];

--- a/src/Generators/SwaggerGenerator.php
+++ b/src/Generators/SwaggerGenerator.php
@@ -31,6 +31,8 @@ class SwaggerGenerator
                     'name'   => $field->name,
                     'type'   => $fieldType,
                     'format' => $fieldFormat,
+                    'nullable' => !$field->isNotNull,
+                    'readOnly' => !$field->isFillable,
                 ];
 
                 $fieldType['description'] = (!empty($field->description)) ? $field->description : '';
@@ -132,7 +134,11 @@ class SwaggerGenerator
             $fieldName = $field['name'];
             $type = $field['type'];
             $format = $field['format'];
+            $nullable = $field['nullable'] ? 'true' : 'false';
+            $readOnly = $field['readOnly'] ? 'true' : 'false';
             $propertyTemplate = str_replace('$FIELD_NAME$', $fieldName, $template);
+            $propertyTemplate = str_replace('$FIELD_NULLABLE$', $nullable, $propertyTemplate);
+            $propertyTemplate = str_replace('$FIELD_READ_ONLY$', $readOnly, $propertyTemplate);
             $description = $field['description'];
             if (empty($description)) {
                 $description = $fieldName;


### PR DESCRIPTION
Newer versions of the OpenAPI/Swagger allow for additional options when building schema properties.

This exposes 'readOnly' and 'nullable' as available replacements when building a schema for a model.

For instance, when defining an OpenAPI property these could be included in the template as follows:

```
cat property.stub 
 *      @OA\Property(
 *          property="$FIELD_NAME$",
 *          description="$DESCRIPTION$",
 *          readOnly=$FIELD_READ_ONLY$,
 *          nullable=$FIELD_NULLABLE$,
 *          type="$FIELD_TYPE$"$FIELD_FORMAT$
 *      )
```

This commit will have no impact on existing templates that don't use these variables but will allow for templates to support OpenAPI if required.