### PR TITLE
Suggested solution for issue #887

### DIFF
--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -175,14 +175,12 @@ class ViewGenerator extends BaseGenerator
             }
 
             if ($localized) {
-                
                 // Replacing $FIELD_NAME$ before fill_template_with_field_data_locale() otherwise also
                 // $FIELD_NAME$ get replaced with @lang('models/$modelName.fields.$value')
                 // and so we don't have $FIELD_NAME$ in table_header_locale.stub
                 // @see issue https://github.com/InfyOmLabs/laravel-generator/issues/887
                 // We could need 'raw' field name in header for example for sorting.
                 // We still have $FIELD_NAME_TITLE$ replaced with @lang('models/$modelName.fields.$value')
-                
                 $preFilledHeaderFieldTemplate = str_replace('$FIELD_NAME$', $field->name, $headerFieldTemplate);
 
                 $headerFields[] = $fieldTemplate = fill_template_with_field_data_locale(

--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -180,7 +180,7 @@ class ViewGenerator extends BaseGenerator
                  * $FIELD_NAME$ get replaced with @lang('models/$modelName.fields.$value')
                  * and so we don't have $FIELD_NAME$ in table_header_locale.stub
                  * We could need 'raw' field name in header for example for sorting.
-                 * We still have $FIELD_NAME_TITLE$ replaced with @lang('models/$modelName.fields.$value')
+                 * We still have $FIELD_NAME_TITLE$ replaced with @lang('models/$modelName.fields.$value').
                  * @see issue https://github.com/InfyOmLabs/laravel-generator/issues/887
                  */
                 $preFilledHeaderFieldTemplate = str_replace('$FIELD_NAME$', $field->name, $headerFieldTemplate);

--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -175,17 +175,14 @@ class ViewGenerator extends BaseGenerator
             }
 
             if ($localized) {
-
                 /**
                  * Replacing $FIELD_NAME$ before fill_template_with_field_data_locale() otherwise also
                  * $FIELD_NAME$ get replaced with @lang('models/$modelName.fields.$value')
                  * and so we don't have $FIELD_NAME$ in table_header_locale.stub
                  * We could need 'raw' field name in header for example for sorting.
                  * We still have $FIELD_NAME_TITLE$ replaced with @lang('models/$modelName.fields.$value')
-                 * 
                  * @see issue https://github.com/InfyOmLabs/laravel-generator/issues/887
                  */
-
                 $preFilledHeaderFieldTemplate = str_replace('$FIELD_NAME$', $field->name, $headerFieldTemplate);
 
                 $headerFields[] = $fieldTemplate = fill_template_with_field_data_locale(
@@ -194,7 +191,6 @@ class ViewGenerator extends BaseGenerator
                     $preFilledHeaderFieldTemplate,
                     $field
                 );
-                
             } else {
                 $headerFields[] = $fieldTemplate = fill_template_with_field_data(
                     $this->commandData->dynamicVars,

--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -175,12 +175,23 @@ class ViewGenerator extends BaseGenerator
             }
 
             if ($localized) {
+                
+                // Replacing $FIELD_NAME$ before fill_template_with_field_data_locale() otherwise also
+                // $FIELD_NAME$ get replaced with @lang('models/$modelName.fields.$value')
+                // and so we don't have $FIELD_NAME$ in table_header_locale.stub
+                // @see issue https://github.com/InfyOmLabs/laravel-generator/issues/887
+                // We could need 'raw' field name in header for example for sorting.
+                // We still have $FIELD_NAME_TITLE$ replaced with @lang('models/$modelName.fields.$value')
+                
+                $preFilledHeaderFieldTemplate = str_replace('$FIELD_NAME$', $field->name, $headerFieldTemplate);
+
                 $headerFields[] = $fieldTemplate = fill_template_with_field_data_locale(
                     $this->commandData->dynamicVars,
                     $this->commandData->fieldNamesMapping,
-                    $headerFieldTemplate,
+                    $preFilledHeaderFieldTemplate,
                     $field
                 );
+                
             } else {
                 $headerFields[] = $fieldTemplate = fill_template_with_field_data(
                     $this->commandData->dynamicVars,

--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -175,12 +175,17 @@ class ViewGenerator extends BaseGenerator
             }
 
             if ($localized) {
-                // Replacing $FIELD_NAME$ before fill_template_with_field_data_locale() otherwise also
-                // $FIELD_NAME$ get replaced with @lang('models/$modelName.fields.$value')
-                // and so we don't have $FIELD_NAME$ in table_header_locale.stub
-                // @see issue https://github.com/InfyOmLabs/laravel-generator/issues/887
-                // We could need 'raw' field name in header for example for sorting.
-                // We still have $FIELD_NAME_TITLE$ replaced with @lang('models/$modelName.fields.$value')
+
+                /**
+                 * Replacing $FIELD_NAME$ before fill_template_with_field_data_locale() otherwise also
+                 * $FIELD_NAME$ get replaced with @lang('models/$modelName.fields.$value')
+                 * and so we don't have $FIELD_NAME$ in table_header_locale.stub
+                 * We could need 'raw' field name in header for example for sorting.
+                 * We still have $FIELD_NAME_TITLE$ replaced with @lang('models/$modelName.fields.$value')
+                 * 
+                 * @see issue https://github.com/InfyOmLabs/laravel-generator/issues/887
+                 */
+
                 $preFilledHeaderFieldTemplate = str_replace('$FIELD_NAME$', $field->name, $headerFieldTemplate);
 
                 $headerFields[] = $fieldTemplate = fill_template_with_field_data_locale(

--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -181,6 +181,7 @@ class ViewGenerator extends BaseGenerator
                  * and so we don't have $FIELD_NAME$ in table_header_locale.stub
                  * We could need 'raw' field name in header for example for sorting.
                  * We still have $FIELD_NAME_TITLE$ replaced with @lang('models/$modelName.fields.$value').
+                 *
                  * @see issue https://github.com/InfyOmLabs/laravel-generator/issues/887
                  */
                 $preFilledHeaderFieldTemplate = str_replace('$FIELD_NAME$', $field->name, $headerFieldTemplate);


### PR DESCRIPTION
Replacing `$FIELD_NAME$` before `fill_template_with_field_data_locale()` otherwise also

`$FIELD_NAME$` get replaced with `@lang('models/$modelName.fields.$value')`

and so we don't have `$FIELD_NAME$` in `table_header_locale.stub`.

@see issue https://github.com/InfyOmLabs/laravel-generator/issues/887

We could need 'raw' field name in header for example for sorting.

We still have $FIELD_NAME_TITLE$ replaced with @lang('models/$modelName.fields.$value')