### PR TITLE
Allow add namespace to views

### DIFF
--- a/src/Common/GeneratorConfig.php
+++ b/src/Common/GeneratorConfig.php
@@ -290,7 +290,11 @@ class GeneratorConfig
         }
 
         if (!empty($this->prefixes['view'])) {
-            $commandData->addDynamicVariable('$VIEW_PREFIX$', str_replace('/', '.', $this->prefixes['view']).'.');
+            if (!empty($this->prefixes['view_namespace'])) {
+                $commandData->addDynamicVariable('$VIEW_PREFIX$', str_replace('/', '.', $this->prefixes['view_namespace'].'::'.$this->prefixes['view']).'.');
+            } else {
+                $commandData->addDynamicVariable('$VIEW_PREFIX$', str_replace('/', '.', $this->prefixes['view']).'.');
+            }
         } else {
             $commandData->addDynamicVariable('$VIEW_PREFIX$', '');
         }
@@ -397,7 +401,19 @@ class GeneratorConfig
     {
         $this->prefixes['route'] = explode('/', config('infyom.laravel_generator.prefixes.route', ''));
         $this->prefixes['path'] = explode('/', config('infyom.laravel_generator.prefixes.path', ''));
-        $this->prefixes['view'] = explode('.', config('infyom.laravel_generator.prefixes.view', ''));
+        
+        /**
+         * Check if exist view namespace when generate views path is inside a package
+         */
+        if(strpos(config('infyom.laravel_generator.prefixes.view', ''), '::') !== false) {
+            $viewNamespaced = explode('::', config('infyom.laravel_generator.prefixes.view', ''));
+            $this->prefixes['view_namespace'] = $viewNamespaced[0];
+            $this->prefixes['view'] = explode('.', $viewNamespaced[1]);
+        } else {
+            $this->prefixes['view_namespace'] = '';
+            $this->prefixes['view'] = explode('.', config('infyom.laravel_generator.prefixes.view', ''));
+        }
+        
         $this->prefixes['public'] = explode('/', config('infyom.laravel_generator.prefixes.public', ''));
 
         if ($this->getOption('prefix')) {

--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -282,7 +282,12 @@ class ViewGenerator extends BaseGenerator
                 }
 
                 $tableName = $this->commandData->config->tableName;
-                $viewPath = $this->commandData->config->prefixes['view'];
+
+                /**
+                 * Add namespace to view
+                 */
+                if(!empty($this->commandData->config->prefixes['view_namespace'])) $viewPath = $this->commandData->config->prefixes['view'];
+                else $viewPath = $this->commandData->config->prefixes['view_namespace'].'::'.$this->commandData->config->prefixes['view'];
                 if (!empty($viewPath)) {
                     $tableName = $viewPath.'.'.$tableName;
                 }


### PR DESCRIPTION
I wanted to generate all code inside a package and this work perfectly fine by just changing path and namespace in configuration of laravel_generator.php

However, the only things that can't be changed is view namespace.

With this change it's possible to add views prefix namespace, so that views are added and load from a package.

In config just add namespace prefix like so:

```php
    'prefixes' => [
        'view' => 'mypackage::admin', 
    ],
```

Where mypackage is namespace when a new path is added from package using:

```
$this->loadViewsFrom(__DIR__.'/../resources/views', 'mypackage');
```

There should not be any BC, nor new configuration. Just a simple check if prefixes.view has "::" and if so storing namespace inside separately from view path. 

Then in GeneratorConfig the dynamic variable **$VIEW_PREFIX$** is replaced with namespace if set.

The same for ViewGenerator for selectTable fields.

I do test with several commands, but not sure if all cases are covered.

If I discover something else regarding generating code inside package, I will advise.

Of course is important to change also all laravel_generator.path and laravel_generator.namespace in config, especially the path.view.

Thanks for merging !



