### PR TITLE
Fixed factories for Laravel 8

### DIFF
--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -139,7 +139,7 @@ class ModelGenerator extends BaseGenerator
         } else {
             $templateData = str_replace(
                 '$HAS_FACTORY_IMPORT$', 
-                'use Illuminate\Database\Eloquent\Factories\HasFactory;', 
+                'use Illuminate\Database\Eloquent\Factories\HasFactory;',
                 $templateData
             );
             $templateData = str_replace('$HAS_FACTORY$', infy_tab()."use HasFactory;\n", $templateData);

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -61,6 +61,8 @@ class ModelGenerator extends BaseGenerator
 
         $templateData = $this->fillSoftDeletes($templateData);
 
+        $templateData = $this->fillHasFactory($templateData);
+
         $fillables = [];
         $primaryKey = 'id';
 
@@ -114,7 +116,7 @@ class ModelGenerator extends BaseGenerator
         } else {
             $templateData = str_replace(
                 '$SOFT_DELETE_IMPORT$',
-                "use Illuminate\\Database\\Eloquent\\SoftDeletes;\n",
+                "use Illuminate\\Database\\Eloquent\\SoftDeletes;",
                 $templateData
             );
             $templateData = str_replace('$SOFT_DELETE$', infy_tab()."use SoftDeletes;\n", $templateData);
@@ -124,6 +126,23 @@ class ModelGenerator extends BaseGenerator
                 infy_nl_tab()."protected \$dates = ['".$deletedAtTimestamp."'];\n",
                 $templateData
             );
+        }
+
+        return $templateData;
+    }
+
+    private function fillHasFactory($templateData)
+    {
+        if (!$this->commandData->getAddOn('tests')) {
+            $templateData = str_replace('$HAS_FACTORY_IMPORT$', '', $templateData);
+            $templateData = str_replace('$HAS_FACTORY$', '', $templateData);
+        } else {
+            $templateData = str_replace(
+                '$HAS_FACTORY_IMPORT$', 
+                "use Illuminate\\Database\\Eloquent\\Factories\\HasFactory;", 
+                $templateData
+            );
+            $templateData = str_replace('$HAS_FACTORY$', infy_tab()."use HasFactory;\n", $templateData);
         }
 
         return $templateData;

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -138,7 +138,7 @@ class ModelGenerator extends BaseGenerator
             $templateData = str_replace('$HAS_FACTORY$', '', $templateData);
         } else {
             $templateData = str_replace(
-                '$HAS_FACTORY_IMPORT$', 
+                '$HAS_FACTORY_IMPORT$',
                 'use Illuminate\Database\Eloquent\Factories\HasFactory;',
                 $templateData
             );

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -116,7 +116,7 @@ class ModelGenerator extends BaseGenerator
         } else {
             $templateData = str_replace(
                 '$SOFT_DELETE_IMPORT$',
-                "use Illuminate\\Database\\Eloquent\\SoftDeletes;",
+                'use Illuminate\Database\Eloquent\SoftDeletes;',
                 $templateData
             );
             $templateData = str_replace('$SOFT_DELETE$', infy_tab()."use SoftDeletes;\n", $templateData);
@@ -139,7 +139,7 @@ class ModelGenerator extends BaseGenerator
         } else {
             $templateData = str_replace(
                 '$HAS_FACTORY_IMPORT$', 
-                "use Illuminate\\Database\\Eloquent\\Factories\\HasFactory;", 
+                'use Illuminate\Database\Eloquent\Factories\HasFactory;', 
                 $templateData
             );
             $templateData = str_replace('$HAS_FACTORY$', infy_tab()."use HasFactory;\n", $templateData);

--- a/templates/api/test/api_test.stub
+++ b/templates/api/test/api_test.stub
@@ -15,7 +15,7 @@ class $MODEL_NAME$ApiTest extends TestCase
      */
     public function test_create_$MODEL_NAME_SNAKE$()
     {
-        $$MODEL_NAME_CAMEL$ = factory($MODEL_NAME$::class)->make()->toArray();
+        $$MODEL_NAME_CAMEL$ = $MODEL_NAME$::factory()->make()->toArray();
 
         $this->response = $this->json(
             'POST',
@@ -30,7 +30,7 @@ class $MODEL_NAME$ApiTest extends TestCase
      */
     public function test_read_$MODEL_NAME_SNAKE$()
     {
-        $$MODEL_NAME_CAMEL$ = factory($MODEL_NAME$::class)->create();
+        $$MODEL_NAME_CAMEL$ = $MODEL_NAME$::factory()->create();
 
         $this->response = $this->json(
             'GET',
@@ -45,8 +45,8 @@ class $MODEL_NAME$ApiTest extends TestCase
      */
     public function test_update_$MODEL_NAME_SNAKE$()
     {
-        $$MODEL_NAME_CAMEL$ = factory($MODEL_NAME$::class)->create();
-        $edited$MODEL_NAME$ = factory($MODEL_NAME$::class)->make()->toArray();
+        $$MODEL_NAME_CAMEL$ = $MODEL_NAME$::factory()->create();
+        $edited$MODEL_NAME$ = $MODEL_NAME$::factory()->make()->toArray();
 
         $this->response = $this->json(
             'PUT',
@@ -62,7 +62,7 @@ class $MODEL_NAME$ApiTest extends TestCase
      */
     public function test_delete_$MODEL_NAME_SNAKE$()
     {
-        $$MODEL_NAME_CAMEL$ = factory($MODEL_NAME$::class)->create();
+        $$MODEL_NAME_CAMEL$ = $MODEL_NAME$::factory()->create();
 
         $this->response = $this->json(
             'DELETE',

--- a/templates/model/model.stub
+++ b/templates/model/model.stub
@@ -4,10 +4,13 @@ namespace $NAMESPACE_MODEL$;
 
 use $NAMESPACE_MODEL_EXTEND$ as Model;
 $SOFT_DELETE_IMPORT$
+$HAS_FACTORY_IMPORT$
+
 $DOCS$
 class $MODEL_NAME$ extends Model
 {
 $SOFT_DELETE$
+$HAS_FACTORY$
     public $table = '$TABLE_NAME$';
     $TIMESTAMPS$
 $SOFT_DELETE_DATES$

--- a/templates/test/repository_test.stub
+++ b/templates/test/repository_test.stub
@@ -26,7 +26,7 @@ class $MODEL_NAME$RepositoryTest extends TestCase
      */
     public function test_create_$MODEL_NAME_SNAKE$()
     {
-        $$MODEL_NAME_CAMEL$ = factory($MODEL_NAME$::class)->make()->toArray();
+        $$MODEL_NAME_CAMEL$ = $MODEL_NAME$::factory()->make()->toArray();
 
         $created$MODEL_NAME$ = $this->$MODEL_NAME_CAMEL$Repo->create($$MODEL_NAME_CAMEL$);
 
@@ -42,7 +42,7 @@ class $MODEL_NAME$RepositoryTest extends TestCase
      */
     public function test_read_$MODEL_NAME_SNAKE$()
     {
-        $$MODEL_NAME_CAMEL$ = factory($MODEL_NAME$::class)->create();
+        $$MODEL_NAME_CAMEL$ = $MODEL_NAME$::factory()->create();
 
         $db$MODEL_NAME$ = $this->$MODEL_NAME_CAMEL$Repo->find($$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
 
@@ -55,8 +55,8 @@ class $MODEL_NAME$RepositoryTest extends TestCase
      */
     public function test_update_$MODEL_NAME_SNAKE$()
     {
-        $$MODEL_NAME_CAMEL$ = factory($MODEL_NAME$::class)->create();
-        $fake$MODEL_NAME$ = factory($MODEL_NAME$::class)->make()->toArray();
+        $$MODEL_NAME_CAMEL$ = $MODEL_NAME$::factory()->create();
+        $fake$MODEL_NAME$ = $MODEL_NAME$::factory()->make()->toArray();
 
         $updated$MODEL_NAME$ = $this->$MODEL_NAME_CAMEL$Repo->update($fake$MODEL_NAME$, $$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
 
@@ -70,7 +70,7 @@ class $MODEL_NAME$RepositoryTest extends TestCase
      */
     public function test_delete_$MODEL_NAME_SNAKE$()
     {
-        $$MODEL_NAME_CAMEL$ = factory($MODEL_NAME$::class)->create();
+        $$MODEL_NAME_CAMEL$ = $MODEL_NAME$::factory()->create();
 
         $resp = $this->$MODEL_NAME_CAMEL$Repo->delete($$MODEL_NAME_CAMEL$->$PRIMARY_KEY_NAME$);
 


### PR DESCRIPTION
In Laravel 8 models have to implement HasFactory trait, and factory(Model::class) is replaced by Model::factory()