### PR TITLE
fix the NULL namespaces

### DIFF
--- a/src/Commands/Publish/LayoutPublishCommand.php
+++ b/src/Commands/Publish/LayoutPublishCommand.php
@@ -142,7 +142,7 @@ class LayoutPublishCommand extends PublishBaseCommand
     {
         $templateData = str_replace(
             '$NAMESPACE_CONTROLLER$',
-            config('infyom.laravel_generator.namespace.controller'),
+            config('infyom.laravel_generator.namespace.controller') ?? 'App\\Http\Controllers',
             $templateData
         );
 

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -191,9 +191,9 @@ class PublishUserCommand extends PublishBaseCommand
      */
     private function fillTemplate($templateData)
     {
-        $templateData = str_replace('$NAMESPACE_CONTROLLER$', config('infyom.laravel_generator.namespace.controller'), $templateData);
+        $templateData = str_replace('$NAMESPACE_CONTROLLER$', config('infyom.laravel_generator.namespace.controller') ?? 'App\\Http\\Controllers', $templateData);
 
-        $templateData = str_replace('$NAMESPACE_REQUEST$', config('infyom.laravel_generator.namespace.request'), $templateData);
+        $templateData = str_replace('$NAMESPACE_REQUEST$', config('infyom.laravel_generator.namespace.request') ?? 'App\\Http\\Requests', $templateData);
 
         $templateData = str_replace('$NAMESPACE_REPOSITORY$', config('infyom.laravel_generator.namespace.repository'), $templateData);
         $templateData = str_replace('$NAMESPACE_USER$', config('auth.providers.users.model'), $templateData);


### PR DESCRIPTION
When running `php artisan infyom.publish:layout` and  `php artisan infyom.publish:user` commands generates a `HomeController`, `UserController`, and `CreateUserRequest` WITH a NULL namepaces in case there is NO value provided in the `config` file So, the `syntax error, unexpected token ";", expecting "{"` is emited