### PR TITLE
Make namespaces more readable

### DIFF
--- a/src/Commands/BaseCommand.php
+++ b/src/Commands/BaseCommand.php
@@ -4,6 +4,10 @@ namespace InfyOm\Generator\Commands;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\API\APIControllerGenerator;
 use InfyOm\Generator\Generators\API\APIRequestGenerator;
@@ -23,8 +27,6 @@ use InfyOm\Generator\Generators\Scaffold\RoutesGenerator;
 use InfyOm\Generator\Generators\Scaffold\ViewGenerator;
 use InfyOm\Generator\Generators\SeederGenerator;
 use InfyOm\Generator\Utils\FileUtil;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 
 class BaseCommand extends Command
 {
@@ -75,8 +77,7 @@ class BaseCommand extends Command
             $repositoryGenerator->generate();
         }
 
-        if ($this->commandData->getOption('factory') || (
-            !$this->isSkip('tests') and $this->commandData->getAddOn('tests')
+        if ($this->commandData->getOption('factory') || (!$this->isSkip('tests') and $this->commandData->getAddOn('tests')
         )) {
             $factoryGenerator = new FactoryGenerator($this->commandData);
             $factoryGenerator->generate();
@@ -227,15 +228,15 @@ class BaseCommand extends Command
         foreach ($this->commandData->relations as $relation) {
             $fileFields[] = [
                 'type'     => 'relation',
-                'relation' => $relation->type.','.implode(',', $relation->inputs),
+                'relation' => $relation->type . ',' . implode(',', $relation->inputs),
             ];
         }
 
         $path = config('infyom.laravel_generator.path.schema_files', resource_path('model_schemas/'));
 
-        $fileName = $this->commandData->modelName.'.json';
+        $fileName = $this->commandData->modelName . '.json';
 
-        if (file_exists($path.$fileName) && !$this->confirmOverwrite($fileName)) {
+        if (file_exists($path . $fileName) && !$this->confirmOverwrite($fileName)) {
             return;
         }
         FileUtil::createFile($path, $fileName, json_encode($fileFields, JSON_PRETTY_PRINT));
@@ -257,12 +258,12 @@ class BaseCommand extends Command
 
         $path = config('infyom.laravel_generator.path.models_locale_files', base_path('resources/lang/en/models/'));
 
-        $fileName = $this->commandData->config->mCamelPlural.'.php';
+        $fileName = $this->commandData->config->mCamelPlural . '.php';
 
-        if (file_exists($path.$fileName) && !$this->confirmOverwrite($fileName)) {
+        if (file_exists($path . $fileName) && !$this->confirmOverwrite($fileName)) {
             return;
         }
-        $content = "<?php\n\nreturn ".var_export($locales, true).';'.\PHP_EOL;
+        $content = "<?php\n\nreturn " . var_export($locales, true) . ';' . \PHP_EOL;
         FileUtil::createFile($path, $fileName, $content);
         $this->commandData->commandComment("\nModel Locale File saved: ");
         $this->commandData->commandInfo($fileName);
@@ -277,7 +278,7 @@ class BaseCommand extends Command
     protected function confirmOverwrite($fileName, $prompt = '')
     {
         $prompt = (empty($prompt))
-            ? $fileName.' already exists. Do you want to overwrite it? [y|N]'
+            ? $fileName . ' already exists. Do you want to overwrite it? [y|N]'
             : $prompt;
 
         return $this->confirm($prompt, false);

--- a/src/Commands/Publish/GeneratorPublishCommand.php
+++ b/src/Commands/Publish/GeneratorPublishCommand.php
@@ -2,8 +2,9 @@
 
 namespace InfyOm\Generator\Commands\Publish;
 
-use InfyOm\Generator\Utils\FileUtil;
 use Symfony\Component\Console\Input\InputOption;
+
+use InfyOm\Generator\Utils\FileUtil;
 
 class GeneratorPublishCommand extends PublishBaseCommand
 {
@@ -61,7 +62,7 @@ class GeneratorPublishCommand extends PublishBaseCommand
 
     private function updateRouteServiceProvider()
     {
-        $routeServiceProviderPath = app_path('Providers'.DIRECTORY_SEPARATOR.'RouteServiceProvider.php');
+        $routeServiceProviderPath = app_path('Providers' . DIRECTORY_SEPARATOR . 'RouteServiceProvider.php');
 
         if (!file_exists($routeServiceProviderPath)) {
             $this->error("Route Service provider not found on $routeServiceProviderPath");
@@ -71,11 +72,11 @@ class GeneratorPublishCommand extends PublishBaseCommand
 
         $fileContent = file_get_contents($routeServiceProviderPath);
 
-        $search = "Route::middleware('api')".PHP_EOL.str(' ')->repeat(16)."->prefix('api')";
+        $search = "Route::middleware('api')" . PHP_EOL . str(' ')->repeat(16) . "->prefix('api')";
         $beforeContent = str($fileContent)->before($search);
         $afterContent = str($fileContent)->after($search);
 
-        $finalContent = $beforeContent.$search.PHP_EOL.str(' ')->repeat(16)."->as('api.')".$afterContent;
+        $finalContent = $beforeContent . $search . PHP_EOL . str(' ')->repeat(16) . "->as('api.')" . $afterContent;
         file_put_contents($routeServiceProviderPath, $finalContent);
 
         return 0;
@@ -95,7 +96,7 @@ class GeneratorPublishCommand extends PublishBaseCommand
 
         $fileName = 'ApiTestTrait.php';
 
-        if (file_exists($testsPath.$fileName) && !$this->confirmOverwrite($fileName)) {
+        if (file_exists($testsPath . $fileName) && !$this->confirmOverwrite($fileName)) {
             return;
         }
 
@@ -125,7 +126,7 @@ class GeneratorPublishCommand extends PublishBaseCommand
 
         $fileName = 'AppBaseController.php';
 
-        if (file_exists($controllerPath.$fileName) && !$this->confirmOverwrite($fileName)) {
+        if (file_exists($controllerPath . $fileName) && !$this->confirmOverwrite($fileName)) {
             return;
         }
 
@@ -146,7 +147,7 @@ class GeneratorPublishCommand extends PublishBaseCommand
 
         $fileName = 'BaseRepository.php';
 
-        if (file_exists($repositoryPath.$fileName) && !$this->confirmOverwrite($fileName)) {
+        if (file_exists($repositoryPath . $fileName) && !$this->confirmOverwrite($fileName)) {
             return;
         }
 
@@ -157,7 +158,7 @@ class GeneratorPublishCommand extends PublishBaseCommand
 
     private function publishLocaleFiles()
     {
-        $localesDir = __DIR__.'/../../../locale/';
+        $localesDir = __DIR__ . '/../../../locale/';
 
         $this->publishDirectory($localesDir, resource_path('lang'), 'lang', true);
 

--- a/src/Commands/Publish/LayoutPublishCommand.php
+++ b/src/Commands/Publish/LayoutPublishCommand.php
@@ -3,8 +3,10 @@
 namespace InfyOm\Generator\Commands\Publish;
 
 use Illuminate\Support\Str;
-use InfyOm\Generator\Utils\FileUtil;
+
 use Symfony\Component\Console\Input\InputOption;
+
+use InfyOm\Generator\Utils\FileUtil;
 
 class LayoutPublishCommand extends PublishBaseCommand
 {
@@ -47,19 +49,19 @@ class LayoutPublishCommand extends PublishBaseCommand
         }
 
         foreach ($files as $stub => $blade) {
-            $sourceFile = get_template_file_path('scaffold/'.$stub, $templateType);
-            $destinationFile = $viewsPath.$blade;
+            $sourceFile = get_template_file_path('scaffold/' . $stub, $templateType);
+            $destinationFile = $viewsPath . $blade;
             $this->publishFile($sourceFile, $destinationFile, $blade);
         }
     }
 
     private function createDirectories($viewsPath)
     {
-        FileUtil::createDirectoryIfNotExist($viewsPath.'layouts');
-        FileUtil::createDirectoryIfNotExist($viewsPath.'auth');
+        FileUtil::createDirectoryIfNotExist($viewsPath . 'layouts');
+        FileUtil::createDirectoryIfNotExist($viewsPath . 'auth');
 
-        FileUtil::createDirectoryIfNotExist($viewsPath.'auth/passwords');
-        FileUtil::createDirectoryIfNotExist($viewsPath.'auth/emails');
+        FileUtil::createDirectoryIfNotExist($viewsPath . 'auth/passwords');
+        FileUtil::createDirectoryIfNotExist($viewsPath . 'auth/emails');
     }
 
     private function getViews()
@@ -122,7 +124,7 @@ class LayoutPublishCommand extends PublishBaseCommand
 
         $fileName = 'HomeController.php';
 
-        if (file_exists($controllerPath.$fileName) && !$this->confirmOverwrite($fileName)) {
+        if (file_exists($controllerPath . $fileName) && !$this->confirmOverwrite($fileName)) {
             return;
         }
 

--- a/src/Commands/Publish/PublishBaseCommand.php
+++ b/src/Commands/Publish/PublishBaseCommand.php
@@ -19,7 +19,7 @@ class PublishBaseCommand extends BaseCommand
 
         copy($sourceFile, $destinationFile);
 
-        $this->comment($fileName.' published');
+        $this->comment($fileName . ' published');
         $this->info($destinationFile);
     }
 
@@ -40,7 +40,7 @@ class PublishBaseCommand extends BaseCommand
         File::makeDirectory($destinationDir, 493, true, true);
         File::copyDirectory($sourceDir, $destinationDir);
 
-        $this->comment($dirName.' published');
+        $this->comment($dirName . ' published');
         $this->info($destinationDir);
 
         return true;

--- a/src/Commands/Publish/PublishTemplateCommand.php
+++ b/src/Commands/Publish/PublishTemplateCommand.php
@@ -43,7 +43,7 @@ class PublishTemplateCommand extends PublishBaseCommand
      */
     public function publishGeneratorTemplates()
     {
-        $templatesPath = __DIR__.'/../../../templates';
+        $templatesPath = __DIR__ . '/../../../templates';
 
         return $this->publishDirectory($templatesPath, $this->templatesDir, 'infyom-generator-templates');
     }
@@ -55,9 +55,9 @@ class PublishTemplateCommand extends PublishBaseCommand
     {
         $templateType = config('infyom.laravel_generator.templates', 'adminlte-templates');
 
-        $templatesPath = get_templates_package_path($templateType).'/templates/scaffold';
+        $templatesPath = get_templates_package_path($templateType) . '/templates/scaffold';
 
-        return $this->publishDirectory($templatesPath, $this->templatesDir.'scaffold', 'infyom-generator-templates/scaffold', true);
+        return $this->publishDirectory($templatesPath, $this->templatesDir . 'scaffold', 'infyom-generator-templates/scaffold', true);
     }
 
     /**

--- a/src/Commands/Publish/PublishUserCommand.php
+++ b/src/Commands/Publish/PublishUserCommand.php
@@ -43,13 +43,13 @@ class PublishUserCommand extends PublishBaseCommand
         $viewsPath = config('infyom.laravel_generator.path.views', resource_path('views/'));
         $templateType = config('infyom.laravel_generator.templates', 'adminlte-templates');
 
-        $this->createDirectories($viewsPath.'users');
+        $this->createDirectories($viewsPath . 'users');
 
         $files = $this->getViews();
 
         foreach ($files as $stub => $blade) {
-            $sourceFile = get_template_file_path('scaffold/'.$stub, $templateType);
-            $destinationFile = $viewsPath.$blade;
+            $sourceFile = get_template_file_path('scaffold/' . $stub, $templateType);
+            $destinationFile = $viewsPath . $blade;
             $this->publishFile($sourceFile, $destinationFile, $blade);
         }
     }
@@ -81,7 +81,7 @@ class PublishUserCommand extends PublishBaseCommand
         $routesTemplate = get_template('routes.user', 'laravel-generator');
         $routesTemplate = $this->fillTemplate($routesTemplate);
 
-        $routeContents .= "\n\n".$routesTemplate;
+        $routeContents .= "\n\n" . $routesTemplate;
 
         file_put_contents($path, $routeContents);
         $this->comment("\nUser route added");
@@ -91,10 +91,10 @@ class PublishUserCommand extends PublishBaseCommand
     {
         $viewsPath = config('infyom.laravel_generator.path.views', resource_path('views/'));
         $templateType = config('infyom.laravel_generator.templates', 'adminlte-templates');
-        $path = $viewsPath.'layouts/menu.blade.php';
+        $path = $viewsPath . 'layouts/menu.blade.php';
         $menuContents = file_get_contents($path);
         $sourceFile = file_get_contents(get_template_file_path('scaffold/users/menu', $templateType));
-        $menuContents .= "\n".$sourceFile;
+        $menuContents .= "\n" . $sourceFile;
 
         file_put_contents($path, $menuContents);
         $this->comment("\nUser Menu added");
@@ -114,7 +114,7 @@ class PublishUserCommand extends PublishBaseCommand
 
         $fileName = 'UserController.php';
 
-        if (file_exists($controllerPath.$fileName) && !$this->confirmOverwrite($fileName)) {
+        if (file_exists($controllerPath . $fileName) && !$this->confirmOverwrite($fileName)) {
             return;
         }
 
@@ -135,7 +135,7 @@ class PublishUserCommand extends PublishBaseCommand
 
         FileUtil::createDirectoryIfNotExist($repositoryPath);
 
-        if (file_exists($repositoryPath.$fileName) && !$this->confirmOverwrite($fileName)) {
+        if (file_exists($repositoryPath . $fileName) && !$this->confirmOverwrite($fileName)) {
             return;
         }
 
@@ -156,7 +156,7 @@ class PublishUserCommand extends PublishBaseCommand
 
         FileUtil::createDirectoryIfNotExist($requestPath);
 
-        if (file_exists($requestPath.$fileName) && !$this->confirmOverwrite($fileName)) {
+        if (file_exists($requestPath . $fileName) && !$this->confirmOverwrite($fileName)) {
             return;
         }
 
@@ -174,7 +174,7 @@ class PublishUserCommand extends PublishBaseCommand
         $requestPath = config('infyom.laravel_generator.path.request', app_path('Http/Requests/'));
 
         $fileName = 'UpdateUserRequest.php';
-        if (file_exists($requestPath.$fileName) && !$this->confirmOverwrite($fileName)) {
+        if (file_exists($requestPath . $fileName) && !$this->confirmOverwrite($fileName)) {
             return;
         }
 

--- a/src/Commands/RollbackGeneratorCommand.php
+++ b/src/Commands/RollbackGeneratorCommand.php
@@ -3,6 +3,11 @@
 namespace InfyOm\Generator\Commands;
 
 use Illuminate\Console\Command;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+use InfyOm\Generator\Utils\FileUtil;
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\API\APIControllerGenerator;
 use InfyOm\Generator\Generators\API\APIRequestGenerator;
@@ -18,9 +23,6 @@ use InfyOm\Generator\Generators\Scaffold\MenuGenerator;
 use InfyOm\Generator\Generators\Scaffold\RequestGenerator;
 use InfyOm\Generator\Generators\Scaffold\RoutesGenerator;
 use InfyOm\Generator\Generators\Scaffold\ViewGenerator;
-use InfyOm\Generator\Utils\FileUtil;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 
 class RollbackGeneratorCommand extends Command
 {

--- a/src/Common/CommandData.php
+++ b/src/Common/CommandData.php
@@ -3,8 +3,10 @@
 namespace InfyOm\Generator\Common;
 
 use Exception;
-use Illuminate\Console\Command;
+
 use Illuminate\Support\Str;
+use Illuminate\Console\Command;
+
 use InfyOm\Generator\Events\GeneratorFileCreated;
 use InfyOm\Generator\Events\GeneratorFileCreating;
 use InfyOm\Generator\Events\GeneratorFileDeleted;
@@ -236,7 +238,7 @@ class CommandData
                         'infyom.laravel_generator.path.schema_files',
                         resource_path('model_schemas/')
                     );
-                    $filePath = $schemaFileDirector.$fieldsFileValue;
+                    $filePath = $schemaFileDirector . $fieldsFileValue;
                 }
 
                 if (!file_exists($filePath)) {

--- a/src/Common/GeneratorConfig.php
+++ b/src/Common/GeneratorConfig.php
@@ -137,19 +137,19 @@ class GeneratorConfig
         $prefix = $this->prefixes['ns'];
 
         if (!empty($prefix)) {
-            $prefix = '\\'.$prefix;
+            $prefix = '\\' . $prefix;
         }
 
         $this->nsApp = $commandData->commandObj->getLaravel()->getNamespace();
         $this->nsApp = substr($this->nsApp, 0, strlen($this->nsApp) - 1);
-        $this->nsRepository = config('infyom.laravel_generator.namespace.repository', 'App\Repositories').$prefix;
-        $this->nsModel = config('infyom.laravel_generator.namespace.model', 'App\Models').$prefix;
+        $this->nsRepository = config('infyom.laravel_generator.namespace.repository', 'App\Repositories') . $prefix;
+        $this->nsModel = config('infyom.laravel_generator.namespace.model', 'App\Models') . $prefix;
         if (config('infyom.laravel_generator.ignore_model_prefix', false)) {
             $this->nsModel = config('infyom.laravel_generator.namespace.model', 'App\Models');
         }
-        $this->nsSeeder = config('infyom.laravel_generator.namespace.seeder', 'Database\Seeders').$prefix;
-        $this->nsFactory = config('infyom.laravel_generator.namespace.factory', 'Database\Factories').$prefix;
-        $this->nsDataTables = config('infyom.laravel_generator.namespace.datatables', 'App\DataTables').$prefix;
+        $this->nsSeeder = config('infyom.laravel_generator.namespace.seeder', 'Database\Seeders') . $prefix;
+        $this->nsFactory = config('infyom.laravel_generator.namespace.factory', 'Database\Factories') . $prefix;
+        $this->nsDataTables = config('infyom.laravel_generator.namespace.datatables', 'App\DataTables') . $prefix;
         $this->nsModelExtend = config(
             'infyom.laravel_generator.model_extend_class',
             'Illuminate\Database\Eloquent\Model'
@@ -158,17 +158,17 @@ class GeneratorConfig
         $this->nsApiController = config(
             'infyom.laravel_generator.namespace.api_controller',
             'App\Http\Controllers\API'
-        ).$prefix;
+        ) . $prefix;
         $this->nsApiResource = config(
             'infyom.laravel_generator.namespace.api_resource',
             'App\Http\Resources'
-        ).$prefix;
-        $this->nsApiRequest = config('infyom.laravel_generator.namespace.api_request', 'App\Http\Requests\API').$prefix;
+        ) . $prefix;
+        $this->nsApiRequest = config('infyom.laravel_generator.namespace.api_request', 'App\Http\Requests\API') . $prefix;
 
-        $this->nsRequest = config('infyom.laravel_generator.namespace.request', 'App\Http\Requests').$prefix;
+        $this->nsRequest = config('infyom.laravel_generator.namespace.request', 'App\Http\Requests') . $prefix;
         $this->nsRequestBase = config('infyom.laravel_generator.namespace.request', 'App\Http\Requests');
         $this->nsBaseController = config('infyom.laravel_generator.namespace.controller', 'App\Http\Controllers');
-        $this->nsController = config('infyom.laravel_generator.namespace.controller', 'App\Http\Controllers').$prefix;
+        $this->nsController = config('infyom.laravel_generator.namespace.controller', 'App\Http\Controllers') . $prefix;
 
         $this->nsApiTests = config('infyom.laravel_generator.namespace.api_test', 'Tests\APIs');
         $this->nsRepositoryTests = config('infyom.laravel_generator.namespace.repository_test', 'Tests\Repositories');
@@ -192,29 +192,29 @@ class GeneratorConfig
         $this->pathRepository = config(
             'infyom.laravel_generator.path.repository',
             app_path('Repositories/')
-        ).$prefix;
+        ) . $prefix;
 
-        $this->pathModel = config('infyom.laravel_generator.path.model', app_path('Models/')).$prefix;
+        $this->pathModel = config('infyom.laravel_generator.path.model', app_path('Models/')) . $prefix;
         if (config('infyom.laravel_generator.ignore_model_prefix', false)) {
             $this->pathModel = config('infyom.laravel_generator.path.model', app_path('Models/'));
         }
 
-        $this->pathDataTables = config('infyom.laravel_generator.path.datatables', app_path('DataTables/')).$prefix;
+        $this->pathDataTables = config('infyom.laravel_generator.path.datatables', app_path('DataTables/')) . $prefix;
 
         $this->pathApiController = config(
             'infyom.laravel_generator.path.api_controller',
             app_path('Http/Controllers/API/')
-        ).$prefix;
+        ) . $prefix;
 
         $this->pathApiResource = config(
             'infyom.laravel_generator.path.api_resource',
             app_path('Http/Resources/')
-        ).$prefix;
+        ) . $prefix;
 
         $this->pathApiRequest = config(
             'infyom.laravel_generator.path.api_request',
             app_path('Http/Requests/API/')
-        ).$prefix;
+        ) . $prefix;
 
         $this->pathApiRoutes = config('infyom.laravel_generator.path.api_routes', base_path('routes/api.php'));
 
@@ -223,9 +223,9 @@ class GeneratorConfig
         $this->pathController = config(
             'infyom.laravel_generator.path.controller',
             app_path('Http/Controllers/')
-        ).$prefix;
+        ) . $prefix;
 
-        $this->pathRequest = config('infyom.laravel_generator.path.request', app_path('Http/Requests/')).$prefix;
+        $this->pathRequest = config('infyom.laravel_generator.path.request', app_path('Http/Requests/')) . $prefix;
 
         $this->pathRoutes = config('infyom.laravel_generator.path.routes', base_path('routes/web.php'));
         $this->pathFactory = config('infyom.laravel_generator.path.factory', database_path('factories/'));
@@ -233,7 +233,7 @@ class GeneratorConfig
         $this->pathViews = config(
             'infyom.laravel_generator.path.views',
             resource_path('views/')
-        ).$viewPrefix.$this->mSnakePlural.'/';
+        ) . $viewPrefix . $this->mSnakePlural . '/';
 
         $this->pathAssets = config(
             'infyom.laravel_generator.path.assets',
@@ -296,13 +296,13 @@ class GeneratorConfig
         $connectionText = '';
         if ($connection = $this->getOption('connection')) {
             $this->connection = $connection;
-            $connectionText = infy_tab(4).'public $connection = "'.$connection.'";';
+            $connectionText = infy_tab(4) . 'public $connection = "' . $connection . '";';
         }
         $commandData->addDynamicVariable('$CONNECTION$', $connectionText);
 
         if (!empty($this->prefixes['route'])) {
-            $commandData->addDynamicVariable('$ROUTE_NAMED_PREFIX$', $this->prefixes['route'].'.');
-            $commandData->addDynamicVariable('$ROUTE_PREFIX$', str_replace('.', '/', $this->prefixes['route']).'/');
+            $commandData->addDynamicVariable('$ROUTE_NAMED_PREFIX$', $this->prefixes['route'] . '.');
+            $commandData->addDynamicVariable('$ROUTE_PREFIX$', str_replace('.', '/', $this->prefixes['route']) . '/');
             $commandData->addDynamicVariable('$RAW_ROUTE_PREFIX$', $this->prefixes['route']);
         } else {
             $commandData->addDynamicVariable('$ROUTE_PREFIX$', '');
@@ -310,13 +310,13 @@ class GeneratorConfig
         }
 
         if (!empty($this->prefixes['ns'])) {
-            $commandData->addDynamicVariable('$PATH_PREFIX$', $this->prefixes['ns'].'\\');
+            $commandData->addDynamicVariable('$PATH_PREFIX$', $this->prefixes['ns'] . '\\');
         } else {
             $commandData->addDynamicVariable('$PATH_PREFIX$', '');
         }
 
         if (!empty($this->prefixes['view'])) {
-            $commandData->addDynamicVariable('$VIEW_PREFIX$', str_replace('/', '.', $this->prefixes['view']).'.');
+            $commandData->addDynamicVariable('$VIEW_PREFIX$', str_replace('/', '.', $this->prefixes['view']) . '.');
         } else {
             $commandData->addDynamicVariable('$VIEW_PREFIX$', '');
         }
@@ -437,7 +437,7 @@ class GeneratorConfig
         $routePrefix = '';
 
         foreach ($this->prefixes['route'] as $singlePrefix) {
-            $routePrefix .= Str::camel($singlePrefix).'.';
+            $routePrefix .= Str::camel($singlePrefix) . '.';
         }
 
         if (!empty($routePrefix)) {
@@ -449,7 +449,7 @@ class GeneratorConfig
         $nsPrefix = '';
 
         foreach ($this->prefixes['path'] as $singlePrefix) {
-            $nsPrefix .= Str::title($singlePrefix).'\\';
+            $nsPrefix .= Str::title($singlePrefix) . '\\';
         }
 
         if (!empty($nsPrefix)) {
@@ -461,7 +461,7 @@ class GeneratorConfig
         $pathPrefix = '';
 
         foreach ($this->prefixes['path'] as $singlePrefix) {
-            $pathPrefix .= Str::title($singlePrefix).'/';
+            $pathPrefix .= Str::title($singlePrefix) . '/';
         }
 
         if (!empty($pathPrefix)) {
@@ -473,7 +473,7 @@ class GeneratorConfig
         $viewPrefix = '';
 
         foreach ($this->prefixes['view'] as $singlePrefix) {
-            $viewPrefix .= Str::camel($singlePrefix).'/';
+            $viewPrefix .= Str::camel($singlePrefix) . '/';
         }
 
         if (!empty($viewPrefix)) {
@@ -485,7 +485,7 @@ class GeneratorConfig
         $publicPrefix = '';
 
         foreach ($this->prefixes['public'] as $singlePrefix) {
-            $publicPrefix .= Str::camel($singlePrefix).'/';
+            $publicPrefix .= Str::camel($singlePrefix) . '/';
         }
 
         if (!empty($publicPrefix)) {

--- a/src/Common/GeneratorField.php
+++ b/src/Common/GeneratorField.php
@@ -42,8 +42,8 @@ class GeneratorField
     {
         $this->dbInput = $dbInput;
         if (!is_null($column)) {
-            $this->dbInput = ($column->getLength() > 0) ? $this->dbInput.','.$column->getLength() : $this->dbInput;
-            $this->dbInput = (!$column->getNotnull()) ? $this->dbInput.':nullable' : $this->dbInput;
+            $this->dbInput = ($column->getLength() > 0) ? $this->dbInput . ',' . $column->getLength() : $this->dbInput;
+            $this->dbInput = (!$column->getNotnull()) ? $this->dbInput . ':nullable' : $this->dbInput;
         }
         $this->prepareMigrationText();
     }
@@ -113,18 +113,18 @@ class GeneratorField
 
         $fieldTypeParams = explode(',', array_shift($inputsArr));
         $this->fieldType = array_shift($fieldTypeParams);
-        $this->migrationText .= $this->fieldType."('".$this->name."'";
+        $this->migrationText .= $this->fieldType . "('" . $this->name . "'";
 
         if ($this->fieldType == 'enum') {
             $this->migrationText .= ', [';
             foreach ($fieldTypeParams as $param) {
-                $this->migrationText .= "'".$param."',";
+                $this->migrationText .= "'" . $param . "',";
             }
             $this->migrationText = substr($this->migrationText, 0, strlen($this->migrationText) - 1);
             $this->migrationText .= ']';
         } else {
             foreach ($fieldTypeParams as $param) {
-                $this->migrationText .= ', '.$param;
+                $this->migrationText .= ', ' . $param;
             }
         }
 
@@ -136,7 +136,7 @@ class GeneratorField
             if ($functionName == 'foreign') {
                 $foreignTable = array_shift($inputParams);
                 $foreignField = array_shift($inputParams);
-                $this->foreignKeyText .= "\$table->foreign('".$this->name."')->references('".$foreignField."')->on('".$foreignTable."')";
+                $this->foreignKeyText .= "\$table->foreign('" . $this->name . "')->references('" . $foreignField . "')->on('" . $foreignTable . "')";
                 if (count($inputParams)) {
                     $cascade = array_shift($inputParams);
                     if ($cascade == 'cascade') {
@@ -145,7 +145,7 @@ class GeneratorField
                 }
                 $this->foreignKeyText .= ';';
             } else {
-                $this->migrationText .= '->'.$functionName;
+                $this->migrationText .= '->' . $functionName;
                 $this->migrationText .= '(';
                 $this->migrationText .= implode(', ', $inputParams);
                 $this->migrationText .= ')';

--- a/src/Common/GeneratorFieldRelation.php
+++ b/src/Common/GeneratorFieldRelation.php
@@ -91,7 +91,7 @@ class GeneratorFieldRelation
 
         if (count($inputs) > 0) {
             $inputFields = implode("', '", $inputs);
-            $inputFields = ", '".$inputFields."'";
+            $inputFields = ", '" . $inputFields . "'";
         } else {
             $inputFields = '';
         }

--- a/src/Criteria/LimitOffsetCriteria.php
+++ b/src/Criteria/LimitOffsetCriteria.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Criteria;
 
 use Illuminate\Http\Request;
+
 use Prettus\Repository\Contracts\CriteriaInterface;
 
 class LimitOffsetCriteria implements CriteriaInterface

--- a/src/Generators/API/APIControllerGenerator.php
+++ b/src/Generators/API/APIControllerGenerator.php
@@ -21,7 +21,7 @@ class APIControllerGenerator extends BaseGenerator
     {
         $this->commandData = $commandData;
         $this->path = $commandData->config->pathApiController;
-        $this->fileName = $this->commandData->modelName.'APIController.php';
+        $this->fileName = $this->commandData->modelName . 'APIController.php';
     }
 
     /**
@@ -69,8 +69,8 @@ class APIControllerGenerator extends BaseGenerator
         }
 
         foreach ($methods as $method) {
-            $key = '$DOC_'.strtoupper($method).'$';
-            $docTemplate = get_template($templatePrefix.'.'.$method, $templateType);
+            $key = '$DOC_' . strtoupper($method) . '$';
+            $docTemplate = get_template($templatePrefix . '.' . $method, $templateType);
             $docTemplate = fill_template($this->commandData->dynamicVars, $docTemplate);
             $templateData = str_replace($key, $docTemplate, $templateData);
         }
@@ -86,7 +86,7 @@ class APIControllerGenerator extends BaseGenerator
     public function rollback()
     {
         if ($this->rollbackFile($this->path, $this->fileName)) {
-            $this->commandData->commandComment('API Controller file deleted: '.$this->fileName);
+            $this->commandData->commandComment('API Controller file deleted: ' . $this->fileName);
         }
     }
 }

--- a/src/Generators/API/APIRequestGenerator.php
+++ b/src/Generators/API/APIRequestGenerator.php
@@ -25,8 +25,8 @@ class APIRequestGenerator extends BaseGenerator
     {
         $this->commandData = $commandData;
         $this->path = $commandData->config->pathApiRequest;
-        $this->createFileName = 'Create'.$this->commandData->modelName.'APIRequest.php';
-        $this->updateFileName = 'Update'.$this->commandData->modelName.'APIRequest.php';
+        $this->createFileName = 'Create' . $this->commandData->modelName . 'APIRequest.php';
+        $this->updateFileName = 'Update' . $this->commandData->modelName . 'APIRequest.php';
     }
 
     /**
@@ -86,11 +86,11 @@ class APIRequestGenerator extends BaseGenerator
     public function rollback()
     {
         if ($this->rollbackFile($this->path, $this->createFileName)) {
-            $this->commandData->commandComment('Create API Request file deleted: '.$this->createFileName);
+            $this->commandData->commandComment('Create API Request file deleted: ' . $this->createFileName);
         }
 
         if ($this->rollbackFile($this->path, $this->updateFileName)) {
-            $this->commandData->commandComment('Update API Request file deleted: '.$this->updateFileName);
+            $this->commandData->commandComment('Update API Request file deleted: ' . $this->updateFileName);
         }
     }
 }

--- a/src/Generators/API/APIResourceGenerator.php
+++ b/src/Generators/API/APIResourceGenerator.php
@@ -21,7 +21,7 @@ class APIResourceGenerator extends BaseGenerator
     {
         $this->commandData = $commandData;
         $this->path = $commandData->config->pathApiResource;
-        $this->fileName = $this->commandData->modelName.'Resource.php';
+        $this->fileName = $this->commandData->modelName . 'Resource.php';
     }
 
     /**
@@ -37,7 +37,7 @@ class APIResourceGenerator extends BaseGenerator
 
         $templateData = str_replace(
             '$RESOURCE_FIELDS$',
-            implode(','.infy_nl_tab(1, 3), $this->generateResourceFields()),
+            implode(',' . infy_nl_tab(1, 3), $this->generateResourceFields()),
             $templateData
         );
 
@@ -51,7 +51,7 @@ class APIResourceGenerator extends BaseGenerator
     {
         $resourceFields = [];
         foreach ($this->commandData->fields as $field) {
-            $resourceFields[] = "'".$field->name."' => \$this->".$field->name;
+            $resourceFields[] = "'" . $field->name . "' => \$this->" . $field->name;
         }
 
         return $resourceFields;
@@ -60,7 +60,7 @@ class APIResourceGenerator extends BaseGenerator
     public function rollback()
     {
         if ($this->rollbackFile($this->path, $this->fileName)) {
-            $this->commandData->commandComment('API Resource file deleted: '.$this->fileName);
+            $this->commandData->commandComment('API Resource file deleted: ' . $this->fileName);
         }
     }
 }

--- a/src/Generators/API/APIRoutesGenerator.php
+++ b/src/Generators/API/APIRoutesGenerator.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Generators\API;
 
 use Illuminate\Support\Str;
+
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\BaseGenerator;
 
@@ -43,17 +44,17 @@ class APIRoutesGenerator extends BaseGenerator
      */
     public function generate()
     {
-        $this->routeContents .= "\n\n".$this->routesTemplate;
+        $this->routeContents .= "\n\n" . $this->routesTemplate;
         $existingRouteContents = file_get_contents($this->path);
-        if (Str::contains($existingRouteContents, "Route::resource('".$this->commandData->config->mDashedPlural."',")) {
-            $this->commandData->commandObj->info('Menu '.$this->commandData->config->mDashedPlural.'is already exists, Skipping Adjustment.');
+        if (Str::contains($existingRouteContents, "Route::resource('" . $this->commandData->config->mDashedPlural . "',")) {
+            $this->commandData->commandObj->info('Menu ' . $this->commandData->config->mDashedPlural . 'is already exists, Skipping Adjustment.');
 
             return;
         }
 
         file_put_contents($this->path, $this->routeContents);
 
-        $this->commandData->commandComment("\n".$this->commandData->config->mCamelPlural.' api routes added.');
+        $this->commandData->commandComment("\n" . $this->commandData->config->mCamelPlural . ' api routes added.');
     }
 
     /**

--- a/src/Generators/API/APITestGenerator.php
+++ b/src/Generators/API/APITestGenerator.php
@@ -21,7 +21,7 @@ class APITestGenerator extends BaseGenerator
     {
         $this->commandData = $commandData;
         $this->path = $commandData->config->pathApiTests;
-        $this->fileName = $this->commandData->modelName.'ApiTest.php';
+        $this->fileName = $this->commandData->modelName . 'ApiTest.php';
     }
 
     public function generate()
@@ -39,7 +39,7 @@ class APITestGenerator extends BaseGenerator
     public function rollback()
     {
         if ($this->rollbackFile($this->path, $this->fileName)) {
-            $this->commandData->commandComment('API Test file deleted: '.$this->fileName);
+            $this->commandData->commandComment('API Test file deleted: ' . $this->fileName);
         }
     }
 }

--- a/src/Generators/BaseGenerator.php
+++ b/src/Generators/BaseGenerator.php
@@ -8,7 +8,7 @@ class BaseGenerator
 {
     public function rollbackFile($path, $fileName)
     {
-        if (file_exists($path.$fileName)) {
+        if (file_exists($path . $fileName)) {
             return FileUtil::deleteFile($path, $fileName);
         }
 

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Generators;
 
 use Illuminate\Support\Str;
+
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Utils\FileUtil;
 use InfyOm\Generator\Utils\GeneratorFieldsInputUtil;
@@ -30,7 +31,7 @@ class FactoryGenerator extends BaseGenerator
     {
         $this->commandData = $commandData;
         $this->path = $commandData->config->pathFactory;
-        $this->fileName = $this->commandData->modelName.'Factory.php';
+        $this->fileName = $this->commandData->modelName . 'Factory.php';
         //setup relations if available
         //assumes relation fields are tailed with _id if not supplied
         if (property_exists($this->commandData, 'relations')) {
@@ -41,13 +42,13 @@ class FactoryGenerator extends BaseGenerator
                     if (isset($r->inputs[1])) {
                         $field = $r->inputs[1];
                     } else {
-                        $field = Str::snake($relation).'_id';
+                        $field = Str::snake($relation) . '_id';
                     }
                     if ($field) {
                         $rel = $relation;
                         $this->relations[$field] = [
                             'relation'      => $rel,
-                            'model_class'   => $this->commandData->config->nsModel.'\\'.$relation,
+                            'model_class'   => $this->commandData->config->nsModel . '\\' . $relation,
                         ];
                     }
                 }
@@ -78,7 +79,7 @@ class FactoryGenerator extends BaseGenerator
 
         $templateData = str_replace(
             '$FIELDS$',
-            implode(','.infy_nl_tab(1, 3), $this->generateFields()),
+            implode(',' . infy_nl_tab(1, 3), $this->generateFields()),
             $templateData
         );
 
@@ -107,7 +108,7 @@ class FactoryGenerator extends BaseGenerator
         $fields = [];
 
         //get model validation rules
-        $class = $this->commandData->config->nsModel.'\\'.$this->commandData->modelName;
+        $class = $this->commandData->config->nsModel . '\\' . $this->commandData->modelName;
         $rules = $class::$rules;
         $relations = array_keys($this->relations);
 
@@ -116,7 +117,7 @@ class FactoryGenerator extends BaseGenerator
                 continue;
             }
 
-            $fieldData = "'".$field->name."' => ".'$this->faker->';
+            $fieldData = "'" . $field->name . "' => " . '$this->faker->';
             $rule = null;
             if (isset($rules[$field->name])) {
                 $rule = $rules[$field->name];
@@ -175,8 +176,8 @@ class FactoryGenerator extends BaseGenerator
                     $fakerData = "date('H:i:s')";
                     break;
                 case 'enum':
-                    $fakerData = 'randomElement('.
-                        GeneratorFieldsInputUtil::prepareValuesArrayStr($field->htmlValues).
+                    $fakerData = 'randomElement(' .
+                        GeneratorFieldsInputUtil::prepareValuesArrayStr($field->htmlValues) .
                         ')';
                     break;
                 default:
@@ -228,7 +229,7 @@ class FactoryGenerator extends BaseGenerator
         $relation = $this->relations[$fieldName]['relation'];
         $variable = Str::camel($relation);
 
-        return "'".$fieldName."' => ".'$'.$variable.'->id';
+        return "'" . $fieldName . "' => " . '$' . $variable . '->id';
     }
 
     /**
@@ -253,7 +254,7 @@ class FactoryGenerator extends BaseGenerator
                 $min = 5;
             }
 
-            return 'text('.'$this->faker->numberBetween('.$min.', '.$max.'))';
+            return 'text(' . '$this->faker->numberBetween(' . $min . ', ' . $max . '))';
         } else {
             return 'text';
         }
@@ -292,13 +293,13 @@ class FactoryGenerator extends BaseGenerator
             $qualifier = $data['model_class'];
             $variable = Str::camel($relation);
             $model = Str::studly($relation);
-            $text .= infy_nl_tab(1, 2).'$'.$variable.' = '.$model.'::first();'.
-            infy_nl_tab(1, 2).
-            'if (!$'.$variable.') {'.
-            infy_nl_tab(1, 3).
-            '$'.$variable.' = '.$model.'::factory()->create();'.
-            infy_nl_tab(1, 2).'}'.infy_nl();
-            $uses .= infy_nl()."use $qualifier;";
+            $text .= infy_nl_tab(1, 2) . '$' . $variable . ' = ' . $model . '::first();' .
+                infy_nl_tab(1, 2) .
+                'if (!$' . $variable . ') {' .
+                infy_nl_tab(1, 3) .
+                '$' . $variable . ' = ' . $model . '::factory()->create();' .
+                infy_nl_tab(1, 2) . '}' . infy_nl();
+            $uses .= infy_nl() . "use $qualifier;";
         }
 
         return [
@@ -310,7 +311,7 @@ class FactoryGenerator extends BaseGenerator
     public function rollback()
     {
         if ($this->rollbackFile($this->path, $this->fileName)) {
-            $this->commandData->commandComment('Factory file deleted: '.$this->fileName);
+            $this->commandData->commandComment('Factory file deleted: ' . $this->fileName);
         }
     }
 }

--- a/src/Generators/MigrationGenerator.php
+++ b/src/Generators/MigrationGenerator.php
@@ -3,10 +3,12 @@
 namespace InfyOm\Generator\Generators;
 
 use File;
+use SplFileInfo;
+
 use Illuminate\Support\Str;
+
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Utils\FileUtil;
-use SplFileInfo;
 
 class MigrationGenerator extends BaseGenerator
 {
@@ -32,7 +34,7 @@ class MigrationGenerator extends BaseGenerator
 
         $tableName = $this->commandData->dynamicVars['$TABLE_NAME$'];
 
-        $fileName = date('Y_m_d_His').'_'.'create_'.strtolower($tableName).'_table.php';
+        $fileName = date('Y_m_d_His') . '_' . 'create_' . strtolower($tableName) . '_table.php';
 
         FileUtil::createFile($this->path, $fileName, $templateData);
 
@@ -86,7 +88,7 @@ class MigrationGenerator extends BaseGenerator
 
     public function rollback()
     {
-        $fileName = 'create_'.$this->commandData->config->tableName.'_table.php';
+        $fileName = 'create_' . $this->commandData->config->tableName . '_table.php';
 
         /** @var SplFileInfo $allFiles */
         $allFiles = File::allFiles($this->path);
@@ -103,7 +105,7 @@ class MigrationGenerator extends BaseGenerator
             foreach ($files as $file) {
                 if (Str::contains($file, $fileName)) {
                     if ($this->rollbackFile($this->path, $file)) {
-                        $this->commandData->commandComment('Migration file deleted: '.$file);
+                        $this->commandData->commandComment('Migration file deleted: ' . $file);
                     }
                     break;
                 }

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Generators;
 
 use Illuminate\Support\Str;
+
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Common\GeneratorFieldRelation;
 use InfyOm\Generator\Utils\FileUtil;
@@ -38,7 +39,7 @@ class ModelGenerator extends BaseGenerator
     {
         $this->commandData = $commandData;
         $this->path = $commandData->config->pathModel;
-        $this->fileName = $this->commandData->modelName.'.php';
+        $this->fileName = $this->commandData->modelName . '.php';
         $this->table = $this->commandData->dynamicVars['$TABLE_NAME$'];
     }
 
@@ -68,7 +69,7 @@ class ModelGenerator extends BaseGenerator
         if (isset($this->commandData->fields) && !empty($this->commandData->fields)) {
             foreach ($this->commandData->fields as $field) {
                 if ($field->isFillable) {
-                    $fillables[] = "'".$field->name."'";
+                    $fillables[] = "'" . $field->name . "'";
                 }
                 if ($field->isPrimary) {
                     $primaryKey = $field->name;
@@ -81,25 +82,25 @@ class ModelGenerator extends BaseGenerator
         $templateData = $this->fillTimestamps($templateData);
 
         if ($this->commandData->getOption('primary')) {
-            $primary = infy_tab()."protected \$primaryKey = '".$this->commandData->getOption('primary')."';\n";
+            $primary = infy_tab() . "protected \$primaryKey = '" . $this->commandData->getOption('primary') . "';\n";
         } else {
             $primary = '';
             if ($this->commandData->getOption('fieldsFile') && $primaryKey != 'id') {
-                $primary = infy_tab()."protected \$primaryKey = '".$primaryKey."';\n";
+                $primary = infy_tab() . "protected \$primaryKey = '" . $primaryKey . "';\n";
             }
         }
 
         $templateData = str_replace('$PRIMARY$', $primary, $templateData);
 
-        $templateData = str_replace('$FIELDS$', implode(','.infy_nl_tab(1, 2), $fillables), $templateData);
+        $templateData = str_replace('$FIELDS$', implode(',' . infy_nl_tab(1, 2), $fillables), $templateData);
 
-        $templateData = str_replace('$RULES$', implode(','.infy_nl_tab(1, 2), $rules), $templateData);
+        $templateData = str_replace('$RULES$', implode(',' . infy_nl_tab(1, 2), $rules), $templateData);
 
-        $templateData = str_replace('$CAST$', implode(','.infy_nl_tab(1, 2), $this->generateCasts()), $templateData);
+        $templateData = str_replace('$CAST$', implode(',' . infy_nl_tab(1, 2), $this->generateCasts()), $templateData);
 
         $templateData = str_replace(
             '$RELATIONS$',
-            fill_template($this->commandData->dynamicVars, implode(PHP_EOL.infy_nl_tab(1, 1), $this->generateRelations())),
+            fill_template($this->commandData->dynamicVars, implode(PHP_EOL . infy_nl_tab(1, 1), $this->generateRelations())),
             $templateData
         );
 
@@ -120,11 +121,11 @@ class ModelGenerator extends BaseGenerator
                 'use Illuminate\Database\Eloquent\SoftDeletes;',
                 $templateData
             );
-            $templateData = str_replace('$SOFT_DELETE$', infy_tab()."use SoftDeletes;\n", $templateData);
+            $templateData = str_replace('$SOFT_DELETE$', infy_tab() . "use SoftDeletes;\n", $templateData);
             $deletedAtTimestamp = config('infyom.laravel_generator.timestamps.deleted_at', 'deleted_at');
             $templateData = str_replace(
                 '$SOFT_DELETE_DATES$',
-                infy_nl_tab()."protected \$dates = ['".$deletedAtTimestamp."'];\n",
+                infy_nl_tab() . "protected \$dates = ['" . $deletedAtTimestamp . "'];\n",
                 $templateData
             );
         }
@@ -143,7 +144,7 @@ class ModelGenerator extends BaseGenerator
                 'use Illuminate\Database\Eloquent\Factories\HasFactory;',
                 $templateData
             );
-            $templateData = str_replace('$HAS_FACTORY$', infy_tab()."use HasFactory;\n", $templateData);
+            $templateData = str_replace('$HAS_FACTORY$', infy_tab() . "use HasFactory;\n", $templateData);
         }
 
         return $templateData;
@@ -165,11 +166,11 @@ class ModelGenerator extends BaseGenerator
             foreach ($this->commandData->relations as $relation) {
                 $field = $relationText = (isset($relation->inputs[0])) ? $relation->inputs[0] : null;
                 if (in_array($field, $fieldsArr)) {
-                    $relationText = $relationText.'_'.$count;
+                    $relationText = $relationText . '_' . $count;
                     $count++;
                 }
 
-                $fillables .= ' * @property '.$this->getPHPDocType($relation->type, $relation, $relationText).PHP_EOL;
+                $fillables .= ' * @property ' . $this->getPHPDocType($relation->type, $relation, $relationText) . PHP_EOL;
                 $fieldsArr[] = $field;
             }
         }
@@ -177,7 +178,7 @@ class ModelGenerator extends BaseGenerator
         if (isset($this->commandData->fields) && !empty($this->commandData->fields)) {
             foreach ($this->commandData->fields as $field) {
                 if ($field->isFillable) {
-                    $fillables .= ' * @property '.$this->getPHPDocType($field->fieldType).' $'.$field->name.PHP_EOL;
+                    $fillables .= ' * @property ' . $this->getPHPDocType($field->fieldType) . ' $' . $field->name . PHP_EOL;
                 }
             }
         }
@@ -205,7 +206,7 @@ class ModelGenerator extends BaseGenerator
             case 'datetime':
                 return 'string|\Carbon\Carbon';
             case '1t1':
-                return '\\'.$this->commandData->config->nsModel.'\\'.$relation->inputs[0].' $'.Str::camel($relationText);
+                return '\\' . $this->commandData->config->nsModel . '\\' . $relation->inputs[0] . ' $' . Str::camel($relationText);
             case 'mt1':
                 if (isset($relation->inputs[1])) {
                     $relationName = str_replace('_id', '', strtolower($relation->inputs[1]));
@@ -213,11 +214,11 @@ class ModelGenerator extends BaseGenerator
                     $relationName = $relationText;
                 }
 
-                return '\\'.$this->commandData->config->nsModel.'\\'.$relation->inputs[0].' $'.Str::camel($relationName);
+                return '\\' . $this->commandData->config->nsModel . '\\' . $relation->inputs[0] . ' $' . Str::camel($relationName);
             case '1tm':
             case 'mtm':
             case 'hmt':
-                return '\Illuminate\Database\Eloquent\Collection $'.Str::camel(Str::plural($relationText));
+                return '\Illuminate\Database\Eloquent\Collection $' . Str::camel(Str::plural($relationText));
             default:
                 $fieldData = SwaggerGenerator::getFieldType($db_type);
                 if (!empty($fieldData['fieldType'])) {
@@ -238,7 +239,7 @@ class ModelGenerator extends BaseGenerator
 
         $template = str_replace(
             '$REQUIRED_FIELDS$',
-            '"'.implode('"'.', '.'"', $this->generateRequiredFields()).'"',
+            '"' . implode('"' . ', ' . '"', $this->generateRequiredFields()) . '"',
             $template
         );
 
@@ -276,7 +277,7 @@ class ModelGenerator extends BaseGenerator
 
         $replace = '';
         if (empty($timestamps)) {
-            $replace = infy_nl_tab()."public \$timestamps = false;\n";
+            $replace = infy_nl_tab() . "public \$timestamps = false;\n";
         }
 
         if ($this->commandData->getOption('fromTable') && !empty($timestamps)) {
@@ -284,8 +285,8 @@ class ModelGenerator extends BaseGenerator
                 return !empty($field) ? "'$field'" : 'null';
             });
 
-            $replace .= infy_nl_tab()."const CREATED_AT = $created_at;";
-            $replace .= infy_nl_tab()."const UPDATED_AT = $updated_at;\n";
+            $replace .= infy_nl_tab() . "const CREATED_AT = $created_at;";
+            $replace .= infy_nl_tab() . "const UPDATED_AT = $updated_at;\n";
         }
 
         return str_replace('$TIMESTAMPS$', $replace, $templateData);
@@ -294,7 +295,7 @@ class ModelGenerator extends BaseGenerator
     private function generateRules()
     {
         $dont_require_fields = config('infyom.laravel_generator.options.hidden_fields', [])
-                + config('infyom.laravel_generator.options.excluded_fields', $this->excluded_fields);
+            + config('infyom.laravel_generator.options.excluded_fields', $this->excluded_fields);
 
         $rules = [];
 
@@ -333,7 +334,7 @@ class ModelGenerator extends BaseGenerator
                             // Enforce a maximum string length if possible.
                             foreach (explode(':', $field->dbInput) as $key => $value) {
                                 if (preg_match('/string,(\d+)/', $value, $matches)) {
-                                    $rule[] = 'max:'.$matches[1];
+                                    $rule[] = 'max:' . $matches[1];
                                 }
                             }
                             break;
@@ -355,7 +356,7 @@ class ModelGenerator extends BaseGenerator
                     });
                     $field->validations = implode('|', $rule);
                 }
-                $rule = "'".$field->name."' => '".$field->validations."'";
+                $rule = "'" . $field->name . "' => '" . $field->validations . "'";
                 $rules[] = $rule;
             }
         }
@@ -370,9 +371,9 @@ class ModelGenerator extends BaseGenerator
         foreach ($this->generateRules() as $rule) {
             if (Str::contains($rule, 'unique:')) {
                 $rule = explode('=>', $rule);
-                $string = '$rules['.trim($rule[0]).'].","';
+                $string = '$rules[' . trim($rule[0]) . '].","';
 
-                $uniqueRules .= '$rules['.trim($rule[0]).'] = '.$string.'.$this->route("'.$tableNameSingular.'");';
+                $uniqueRules .= '$rules[' . trim($rule[0]) . '] = ' . $string . '.$this->route("' . $tableNameSingular . '");';
             }
         }
 
@@ -390,7 +391,7 @@ class ModelGenerator extends BaseGenerator
                 continue;
             }
 
-            $rule = "'".$field->name."' => ";
+            $rule = "'" . $field->name . "' => ";
 
             switch (strtolower($field->fieldType)) {
                 case 'integer':
@@ -450,7 +451,7 @@ class ModelGenerator extends BaseGenerator
 
                 $relationShipText = $field;
                 if (in_array($field, $fieldsArr)) {
-                    $relationShipText = $relationShipText.'_'.$count;
+                    $relationShipText = $relationShipText . '_' . $count;
                     $count++;
                 }
 
@@ -468,7 +469,7 @@ class ModelGenerator extends BaseGenerator
     public function rollback()
     {
         if ($this->rollbackFile($this->path, $this->fileName)) {
-            $this->commandData->commandComment('Model file deleted: '.$this->fileName);
+            $this->commandData->commandComment('Model file deleted: ' . $this->fileName);
         }
     }
 }

--- a/src/Generators/RepositoryGenerator.php
+++ b/src/Generators/RepositoryGenerator.php
@@ -20,7 +20,7 @@ class RepositoryGenerator extends BaseGenerator
     {
         $this->commandData = $commandData;
         $this->path = $commandData->config->pathRepository;
-        $this->fileName = $this->commandData->modelName.'Repository.php';
+        $this->fileName = $this->commandData->modelName . 'Repository.php';
     }
 
     public function generate()
@@ -33,11 +33,11 @@ class RepositoryGenerator extends BaseGenerator
 
         foreach ($this->commandData->fields as $field) {
             if ($field->isSearchable) {
-                $searchables[] = "'".$field->name."'";
+                $searchables[] = "'" . $field->name . "'";
             }
         }
 
-        $templateData = str_replace('$FIELDS$', implode(','.infy_nl_tab(1, 2), $searchables), $templateData);
+        $templateData = str_replace('$FIELDS$', implode(',' . infy_nl_tab(1, 2), $searchables), $templateData);
 
         $docsTemplate = get_template('docs.repository', 'laravel-generator');
         $docsTemplate = fill_template($this->commandData->dynamicVars, $docsTemplate);
@@ -54,7 +54,7 @@ class RepositoryGenerator extends BaseGenerator
     public function rollback()
     {
         if ($this->rollbackFile($this->path, $this->fileName)) {
-            $this->commandData->commandComment('Repository file deleted: '.$this->fileName);
+            $this->commandData->commandComment('Repository file deleted: ' . $this->fileName);
         }
     }
 }

--- a/src/Generators/RepositoryTestGenerator.php
+++ b/src/Generators/RepositoryTestGenerator.php
@@ -20,7 +20,7 @@ class RepositoryTestGenerator extends BaseGenerator
     {
         $this->commandData = $commandData;
         $this->path = config('infyom.laravel_generator.path.repository_test', base_path('tests/Repositories/'));
-        $this->fileName = $this->commandData->modelName.'RepositoryTest.php';
+        $this->fileName = $this->commandData->modelName . 'RepositoryTest.php';
     }
 
     public function generate()
@@ -45,7 +45,7 @@ class RepositoryTestGenerator extends BaseGenerator
     public function rollback()
     {
         if ($this->rollbackFile($this->path, $this->fileName)) {
-            $this->commandData->commandComment('Repository Test file deleted: '.$this->fileName);
+            $this->commandData->commandComment('Repository Test file deleted: ' . $this->fileName);
         }
     }
 }

--- a/src/Generators/Scaffold/ControllerGenerator.php
+++ b/src/Generators/Scaffold/ControllerGenerator.php
@@ -25,7 +25,7 @@ class ControllerGenerator extends BaseGenerator
         $this->commandData = $commandData;
         $this->path = $commandData->config->pathController;
         $this->templateType = config('infyom.laravel_generator.templates', 'adminlte-templates');
-        $this->fileName = $this->commandData->modelName.'Controller.php';
+        $this->fileName = $this->commandData->modelName . 'Controller.php';
     }
 
     public function generate()
@@ -64,7 +64,7 @@ class ControllerGenerator extends BaseGenerator
             $paginate = $this->commandData->getOption('paginate');
 
             if ($paginate) {
-                $templateData = str_replace('$RENDER_TYPE$', 'paginate('.$paginate.')', $templateData);
+                $templateData = str_replace('$RENDER_TYPE$', 'paginate(' . $paginate . ')', $templateData);
             } else {
                 $templateData = str_replace('$RENDER_TYPE$', 'all()', $templateData);
             }
@@ -85,19 +85,19 @@ class ControllerGenerator extends BaseGenerator
             $templateName .= '_locale';
         }
 
-        $templateData = get_template('scaffold.'.$templateName, 'laravel-generator');
+        $templateData = get_template('scaffold.' . $templateName, 'laravel-generator');
 
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
 
         $templateData = str_replace(
             '$DATATABLE_COLUMNS$',
-            implode(','.infy_nl_tab(1, 3), $this->generateDataTableColumns()),
+            implode(',' . infy_nl_tab(1, 3), $this->generateDataTableColumns()),
             $templateData
         );
 
         $path = $this->commandData->config->pathDataTables;
 
-        $fileName = $this->commandData->modelName.'DataTable.php';
+        $fileName = $this->commandData->modelName . 'DataTable.php';
 
         FileUtil::createFile($path, $fileName, $templateData);
 
@@ -111,7 +111,7 @@ class ControllerGenerator extends BaseGenerator
         if ($this->commandData->isLocalizedTemplates()) {
             $templateName .= '_locale';
         }
-        $headerFieldTemplate = get_template('scaffold.views.'.$templateName, $this->templateType);
+        $headerFieldTemplate = get_template('scaffold.views.' . $templateName, $this->templateType);
 
         $dataTableColumns = [];
         foreach ($this->commandData->fields as $field) {
@@ -136,7 +136,7 @@ class ControllerGenerator extends BaseGenerator
                 if ($this->commandData->isLocalizedTemplates()) {
                     $dataTableColumns[] = $fieldTemplate;
                 } else {
-                    $dataTableColumns[] = "'".$field->name."' => ['searchable' => false]";
+                    $dataTableColumns[] = "'" . $field->name . "' => ['searchable' => false]";
                 }
             }
         }
@@ -147,15 +147,15 @@ class ControllerGenerator extends BaseGenerator
     public function rollback()
     {
         if ($this->rollbackFile($this->path, $this->fileName)) {
-            $this->commandData->commandComment('Controller file deleted: '.$this->fileName);
+            $this->commandData->commandComment('Controller file deleted: ' . $this->fileName);
         }
 
         if ($this->commandData->getAddOn('datatables')) {
             if ($this->rollbackFile(
                 $this->commandData->config->pathDataTables,
-                $this->commandData->modelName.'DataTable.php'
+                $this->commandData->modelName . 'DataTable.php'
             )) {
-                $this->commandData->commandComment('DataTable file deleted: '.$this->fileName);
+                $this->commandData->commandComment('DataTable file deleted: ' . $this->fileName);
             }
         }
     }

--- a/src/Generators/Scaffold/JQueryDatatableAssetsGenerator.php
+++ b/src/Generators/Scaffold/JQueryDatatableAssetsGenerator.php
@@ -25,9 +25,9 @@ class JQueryDatatableAssetsGenerator extends BaseGenerator
     public function __construct(CommandData $commandData)
     {
         $this->commandData = $commandData;
-        $this->path = $commandData->config->pathAssets.'js/';
+        $this->path = $commandData->config->pathAssets . 'js/';
         $this->config = $this->commandData->config;
-        $this->fileName = $this->config->tableName.'.js';
+        $this->fileName = $this->config->tableName . '.js';
     }
 
     public function generate()
@@ -60,39 +60,39 @@ class JQueryDatatableAssetsGenerator extends BaseGenerator
         }
 
         // Publish Datatable JS file
-        $templateData = get_template('scaffold.'.$templateName, 'laravel-generator');
+        $templateData = get_template('scaffold.' . $templateName, 'laravel-generator');
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
         $templateData = str_replace('$ACTION_COLUMN_COUNT$', $columnsCount, $templateData);
         $templateData = str_replace('$JQUERY_FIELDS$', $fields, $templateData);
 
-        $path = $this->path.$this->config->tableName.'/';
+        $path = $this->path . $this->config->tableName . '/';
         if (!file_exists($path)) {
             FileUtil::createDirectoryIfNotExist($path);
         }
-        file_put_contents($path.$this->fileName, $templateData);
-        $this->commandData->commandComment("\n".$this->config->tableName.' assets added.');
+        file_put_contents($path . $this->fileName, $templateData);
+        $this->commandData->commandComment("\n" . $this->config->tableName . ' assets added.');
 
         // Publish JS Rendere Template
         $templateName = 'js_renderer_template';
-        $templateData = get_template('scaffold.'.$templateName, 'laravel-generator');
+        $templateData = get_template('scaffold.' . $templateName, 'laravel-generator');
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
 
-        $path = $this->config->pathViews.'templates/';
+        $path = $this->config->pathViews . 'templates/';
         if (!file_exists($path)) {
             FileUtil::createDirectoryIfNotExist($path);
         }
 
-        file_put_contents($path.'templates.php', $templateData);
-        $this->commandData->commandComment("\n".'JS Render Templates added.');
+        file_put_contents($path . 'templates.php', $templateData);
+        $this->commandData->commandComment("\n" . 'JS Render Templates added.');
 
         // Publish Webpack mix lines
         $webpackMixContents = file_get_contents(base_path('webpack.mix.js'));
         $templateName = 'webpack_mix_js';
-        $templateData = get_template('scaffold.'.$templateName, 'laravel-generator');
+        $templateData = get_template('scaffold.' . $templateName, 'laravel-generator');
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
-        $webpackMixContents .= "\n\n".$templateData;
+        $webpackMixContents .= "\n\n" . $templateData;
 
         file_put_contents(base_path('webpack.mix.js'), $webpackMixContents);
-        $this->commandData->commandComment("\n".$this->commandData->config->mCamelPlural.' webpack.mix.js updated.');
+        $this->commandData->commandComment("\n" . $this->commandData->config->mCamelPlural . ' webpack.mix.js updated.');
     }
 }

--- a/src/Generators/Scaffold/MenuGenerator.php
+++ b/src/Generators/Scaffold/MenuGenerator.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Generators\Scaffold;
 
 use Illuminate\Support\Str;
+
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\BaseGenerator;
 
@@ -31,7 +32,7 @@ class MenuGenerator extends BaseGenerator
             resource_path(
                 'views/'
             )
-        ).$commandData->getAddOn('menu.menu_file');
+        ) . $commandData->getAddOn('menu.menu_file');
         $this->templateType = config('infyom.laravel_generator.templates', 'adminlte-templates');
 
         $this->menuContents = file_get_contents($this->path);
@@ -42,25 +43,27 @@ class MenuGenerator extends BaseGenerator
             $templateName .= '_locale';
         }
 
-        $this->menuTemplate = get_template('scaffold.layouts.'.$templateName, $this->templateType);
+        $this->menuTemplate = get_template('scaffold.layouts.' . $templateName, $this->templateType);
 
         $this->menuTemplate = fill_template($this->commandData->dynamicVars, $this->menuTemplate);
     }
 
     public function generate()
     {
-        $this->menuContents .= $this->menuTemplate.infy_nl();
+        $this->menuContents .= $this->menuTemplate . infy_nl();
         $existingMenuContents = file_get_contents($this->path);
         // adminlte uses <p> tab and coreui+stisla uses <span> tag for menu
-        if (Str::contains($existingMenuContents, '<p>'.$this->commandData->config->mHumanPlural.'</p>') or
-            Str::contains($existingMenuContents, '<span>'.$this->commandData->config->mHumanPlural.'</span>')) {
-            $this->commandData->commandObj->info('Menu '.$this->commandData->config->mHumanPlural.' is already exists, Skipping Adjustment.');
+        if (
+            Str::contains($existingMenuContents, '<p>' . $this->commandData->config->mHumanPlural . '</p>') or
+            Str::contains($existingMenuContents, '<span>' . $this->commandData->config->mHumanPlural . '</span>')
+        ) {
+            $this->commandData->commandObj->info('Menu ' . $this->commandData->config->mHumanPlural . ' is already exists, Skipping Adjustment.');
 
             return;
         }
 
         file_put_contents($this->path, $this->menuContents);
-        $this->commandData->commandComment("\n".$this->commandData->config->mCamelPlural.' menu added.');
+        $this->commandData->commandComment("\n" . $this->commandData->config->mCamelPlural . ' menu added.');
     }
 
     public function rollback()

--- a/src/Generators/Scaffold/RequestGenerator.php
+++ b/src/Generators/Scaffold/RequestGenerator.php
@@ -25,8 +25,8 @@ class RequestGenerator extends BaseGenerator
     {
         $this->commandData = $commandData;
         $this->path = $commandData->config->pathRequest;
-        $this->createFileName = 'Create'.$this->commandData->modelName.'Request.php';
-        $this->updateFileName = 'Update'.$this->commandData->modelName.'Request.php';
+        $this->createFileName = 'Create' . $this->commandData->modelName . 'Request.php';
+        $this->updateFileName = 'Update' . $this->commandData->modelName . 'Request.php';
     }
 
     public function generate()
@@ -66,11 +66,11 @@ class RequestGenerator extends BaseGenerator
     public function rollback()
     {
         if ($this->rollbackFile($this->path, $this->createFileName)) {
-            $this->commandData->commandComment('Create Request file deleted: '.$this->createFileName);
+            $this->commandData->commandComment('Create Request file deleted: ' . $this->createFileName);
         }
 
         if ($this->rollbackFile($this->path, $this->updateFileName)) {
-            $this->commandData->commandComment('Update Request file deleted: '.$this->updateFileName);
+            $this->commandData->commandComment('Update Request file deleted: ' . $this->updateFileName);
         }
     }
 }

--- a/src/Generators/Scaffold/RoutesGenerator.php
+++ b/src/Generators/Scaffold/RoutesGenerator.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Generators\Scaffold;
 
 use Illuminate\Support\Str;
+
 use InfyOm\Generator\Common\CommandData;
 
 class RoutesGenerator
@@ -24,32 +25,36 @@ class RoutesGenerator
         $this->commandData = $commandData;
         $this->path = $commandData->config->pathRoutes;
         $this->routeContents = file_get_contents($this->path);
+
         if (!empty($this->commandData->config->prefixes['route'])) {
             $this->routesTemplate = get_template('scaffold.routes.prefix_routes', 'laravel-generator');
         } else {
             $this->routesTemplate = get_template('scaffold.routes.routes', 'laravel-generator');
         }
+
         $this->routesTemplate = fill_template($this->commandData->dynamicVars, $this->routesTemplate);
     }
 
     public function generate()
     {
-        $this->routeContents .= "\n\n".$this->routesTemplate;
+        $this->routeContents .= "\n\n" . $this->routesTemplate;
         $existingRouteContents = file_get_contents($this->path);
-        if (Str::contains($existingRouteContents, "Route::resource('".$this->commandData->config->mDashedPlural."',")) {
-            $this->commandData->commandObj->info('Route '.$this->commandData->config->mDashedPlural.' is already exists, Skipping Adjustment.');
+
+        if (Str::contains($existingRouteContents, "Route::resource('" . $this->commandData->config->mDashedPlural . "',")) {
+            $this->commandData->commandObj->info('Route ' . $this->commandData->config->mDashedPlural . ' is already exists, Skipping Adjustment.');
 
             return;
         }
 
         file_put_contents($this->path, $this->routeContents);
-        $this->commandData->commandComment("\n".$this->commandData->config->mCamelPlural.' routes added.');
+        $this->commandData->commandComment("\n" . $this->commandData->config->mCamelPlural . ' routes added.');
     }
 
     public function rollback()
     {
         if (Str::contains($this->routeContents, $this->routesTemplate)) {
             $this->routeContents = str_replace($this->routesTemplate, '', $this->routeContents);
+
             file_put_contents($this->path, $this->routeContents);
             $this->commandData->commandComment('scaffold routes deleted');
         }

--- a/src/Generators/Scaffold/ViewGenerator.php
+++ b/src/Generators/Scaffold/ViewGenerator.php
@@ -4,6 +4,7 @@ namespace InfyOm\Generator\Generators\Scaffold;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
+
 use InfyOm\Generator\Common\CommandData;
 use InfyOm\Generator\Generators\BaseGenerator;
 use InfyOm\Generator\Generators\ViewServiceProviderGenerator;
@@ -110,7 +111,7 @@ class ViewGenerator extends BaseGenerator
             $templateName .= '_locale';
         }
 
-        $templateData = get_template('scaffold.views.'.$templateName, $this->templateType);
+        $templateData = get_template('scaffold.views.' . $templateName, $this->templateType);
 
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
 
@@ -133,7 +134,7 @@ class ViewGenerator extends BaseGenerator
             $templateName .= '_locale';
         }
 
-        $templateData = get_template('scaffold.views.'.$templateName, $this->templateType);
+        $templateData = get_template('scaffold.views.' . $templateName, $this->templateType);
 
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
 
@@ -169,7 +170,7 @@ class ViewGenerator extends BaseGenerator
                 continue;
             }
 
-            $fields .= '<th scope="col">'.str_replace("'", '', $field->name).'</th>';
+            $fields .= '<th scope="col">' . str_replace("'", '', $field->name) . '</th>';
         }
 
         return $fields;
@@ -185,7 +186,7 @@ class ViewGenerator extends BaseGenerator
             $localized = true;
         }
 
-        $headerFieldTemplate = get_template('scaffold.views.'.$templateName, $this->templateType);
+        $headerFieldTemplate = get_template('scaffold.views.' . $templateName, $this->templateType);
 
         $headerFields = [];
 
@@ -233,7 +234,7 @@ class ViewGenerator extends BaseGenerator
             $templateName .= '_locale';
         }
 
-        $templateData = get_template('scaffold.views.'.$templateName, $this->templateType);
+        $templateData = get_template('scaffold.views.' . $templateName, $this->templateType);
 
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
 
@@ -301,7 +302,7 @@ class ViewGenerator extends BaseGenerator
                 $inputArr = explode(',', $field->htmlValues[1]);
                 $columns = '';
                 foreach ($inputArr as $item) {
-                    $columns .= "'$item'".',';  //e.g 'email,id,'
+                    $columns .= "'$item'" . ',';  //e.g 'email,id,'
                 }
                 $columns = substr_replace($columns, '', -1); // remove last ,
 
@@ -315,10 +316,10 @@ class ViewGenerator extends BaseGenerator
                 $tableName = $this->commandData->config->tableName;
                 $viewPath = $this->commandData->config->prefixes['view'];
                 if (!empty($viewPath)) {
-                    $tableName = $viewPath.'.'.$tableName;
+                    $tableName = $viewPath . '.' . $tableName;
                 }
 
-                $variableName = Str::singular($selectTable).'Items'; // e.g $userItems
+                $variableName = Str::singular($selectTable) . 'Items'; // e.g $userItems
 
                 $fieldTemplate = $this->generateViewComposer($tableName, $variableName, $columns, $selectTable, $modalName);
             }
@@ -334,7 +335,7 @@ class ViewGenerator extends BaseGenerator
             }
         }
 
-        $templateData = get_template('scaffold.views.'.$templateName, $this->templateType);
+        $templateData = get_template('scaffold.views.' . $templateName, $this->templateType);
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
 
         $templateData = str_replace('$FIELDS$', implode("\n\n", $this->htmlFields), $templateData);
@@ -353,11 +354,11 @@ class ViewGenerator extends BaseGenerator
 
         $viewServiceProvider = new ViewServiceProviderGenerator($this->commandData);
         $viewServiceProvider->generate();
-        $viewServiceProvider->addViewVariables($tableName.'.fields', $variableName, $columns, $selectTable, $modelName);
+        $viewServiceProvider->addViewVariables($tableName . '.fields', $variableName, $columns, $selectTable, $modelName);
 
         $fieldTemplate = str_replace(
             '$INPUT_ARR$',
-            '$'.$variableName,
+            '$' . $variableName,
             $fieldTemplate
         );
 
@@ -372,7 +373,7 @@ class ViewGenerator extends BaseGenerator
             $templateName .= '_locale';
         }
 
-        $templateData = get_template('scaffold.views.'.$templateName, $this->templateType);
+        $templateData = get_template('scaffold.views.' . $templateName, $this->templateType);
 
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
 
@@ -388,7 +389,7 @@ class ViewGenerator extends BaseGenerator
             $templateName .= '_locale';
         }
 
-        $templateData = get_template('scaffold.views.'.$templateName, $this->templateType);
+        $templateData = get_template('scaffold.views.' . $templateName, $this->templateType);
 
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
 
@@ -402,7 +403,7 @@ class ViewGenerator extends BaseGenerator
         if ($this->commandData->isLocalizedTemplates()) {
             $templateName .= '_locale';
         }
-        $fieldTemplate = get_template('scaffold.views.'.$templateName, $this->templateType);
+        $fieldTemplate = get_template('scaffold.views.' . $templateName, $this->templateType);
 
         $fieldsStr = '';
 
@@ -418,7 +419,7 @@ class ViewGenerator extends BaseGenerator
             $singleFieldStr = str_replace('$FIELD_NAME$', $field->name, $singleFieldStr);
             $singleFieldStr = fill_template($this->commandData->dynamicVars, $singleFieldStr);
 
-            $fieldsStr .= $singleFieldStr."\n\n";
+            $fieldsStr .= $singleFieldStr . "\n\n";
         }
 
         FileUtil::createFile($this->path, 'show_fields.blade.php', $fieldsStr);
@@ -433,7 +434,7 @@ class ViewGenerator extends BaseGenerator
             $templateName .= '_locale';
         }
 
-        $templateData = get_template('scaffold.views.'.$templateName, $this->templateType);
+        $templateData = get_template('scaffold.views.' . $templateName, $this->templateType);
 
         $templateData = fill_template($this->commandData->dynamicVars, $templateData);
 
@@ -456,7 +457,7 @@ class ViewGenerator extends BaseGenerator
         if (!empty($views)) {
             $files = [];
             foreach ($views as $view) {
-                $files[] = $view.'.blade.php';
+                $files[] = $view . '.blade.php';
             }
         }
 
@@ -466,7 +467,7 @@ class ViewGenerator extends BaseGenerator
 
         foreach ($files as $file) {
             if ($this->rollbackFile($this->path, $file)) {
-                $this->commandData->commandComment($file.' file deleted');
+                $this->commandData->commandComment($file . ' file deleted');
             }
         }
     }

--- a/src/Generators/SeederGenerator.php
+++ b/src/Generators/SeederGenerator.php
@@ -26,7 +26,7 @@ class SeederGenerator extends BaseGenerator
     {
         $this->commandData = $commandData;
         $this->path = $commandData->config->pathSeeder;
-        $this->fileName = $this->commandData->config->mPlural.'TableSeeder.php';
+        $this->fileName = $this->commandData->config->mPlural . 'TableSeeder.php';
     }
 
     public function generate()

--- a/src/Generators/SwaggerGenerator.php
+++ b/src/Generators/SwaggerGenerator.php
@@ -109,7 +109,7 @@ class SwaggerGenerator
 
         $templateData = fill_template($variables, $template);
 
-        $templateData = str_replace('$REQUIRED_FIELDS$', '"'.implode('", "', $fillables).'"', $templateData);
+        $templateData = str_replace('$REQUIRED_FIELDS$', '"' . implode('", "', $fillables) . '"', $templateData);
 
         $propertyTemplate = get_template('model_docs.property', 'swagger-generator');
 
@@ -146,7 +146,7 @@ class SwaggerGenerator
             $propertyTemplate = str_replace('$DESCRIPTION$', $description, $propertyTemplate);
             $propertyTemplate = str_replace('$FIELD_TYPE$', $type, $propertyTemplate);
             if (!empty($format)) {
-                $format = ",\n *          format=\"".$format.'"';
+                $format = ",\n *          format=\"" . $format . '"';
             }
             $propertyTemplate = str_replace('$FIELD_FORMAT$', $format, $propertyTemplate);
             $templates[] = $propertyTemplate;

--- a/src/Generators/ViewServiceProviderGenerator.php
+++ b/src/Generators/ViewServiceProviderGenerator.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator\Generators;
 
 use File;
+
 use InfyOm\Generator\Common\CommandData;
 
 /**
@@ -38,7 +39,7 @@ class ViewServiceProviderGenerator extends BaseGenerator
         }
         File::copy($templateData, $destination);
 
-        $this->commandData->commandComment($fileName.' published');
+        $this->commandData->commandComment($fileName . ' published');
         $this->commandData->commandInfo($fileName);
     }
 
@@ -61,7 +62,7 @@ class ViewServiceProviderGenerator extends BaseGenerator
         $this->commandData->addDynamicVariable('$COMPOSER_VIEW_VARIABLE$', $variableName);
         $this->commandData->addDynamicVariable(
             '$COMPOSER_VIEW_VARIABLE_VALUES$',
-            $model."::pluck($columns)->toArray()"
+            $model . "::pluck($columns)->toArray()"
         );
 
         $mainViewContent = $this->addViewComposer();
@@ -78,7 +79,7 @@ class ViewServiceProviderGenerator extends BaseGenerator
         $newViewStatement = get_template('scaffold.view_composer', 'laravel-generator');
         $newViewStatement = fill_template($this->commandData->dynamicVars, $newViewStatement);
 
-        $newViewStatement = infy_nl(1).$newViewStatement;
+        $newViewStatement = infy_nl(1) . $newViewStatement;
         preg_match_all('/public function boot(.*)/', $mainViewContent, $matches);
 
         $totalMatches = count($matches[0]);
@@ -97,7 +98,7 @@ class ViewServiceProviderGenerator extends BaseGenerator
 
     public function addCustomProvider()
     {
-        $configFile = base_path().'/config/app.php';
+        $configFile = base_path() . '/config/app.php';
         $file = file_get_contents($configFile);
         $searchFor = 'Illuminate\View\ViewServiceProvider::class,';
         $customProviders = strpos($file, $searchFor);
@@ -106,7 +107,7 @@ class ViewServiceProviderGenerator extends BaseGenerator
         if ($customProviders && !$isExist) {
             $newChanges = substr_replace(
                 $file,
-                infy_nl().infy_tab(8).'\App\Providers\ViewServiceProvider::class,',
+                infy_nl() . infy_tab(8) . '\App\Providers\ViewServiceProvider::class,',
                 $customProviders + strlen($searchFor),
                 0
             );
@@ -116,9 +117,9 @@ class ViewServiceProviderGenerator extends BaseGenerator
 
     public function addNamespace($model, $mainViewContent)
     {
-        $newModelStatement = 'use '.$this->commandData->config->nsModel.'\\'.$model.';';
+        $newModelStatement = 'use ' . $this->commandData->config->nsModel . '\\' . $model . ';';
         $isNameSpaceExist = strpos($mainViewContent, $newModelStatement);
-        $newModelStatement = infy_nl().$newModelStatement;
+        $newModelStatement = infy_nl() . $newModelStatement;
         if (!$isNameSpaceExist) {
             preg_match_all('/namespace(.*)/', $mainViewContent, $matches);
             $totalMatches = count($matches[0]);

--- a/src/InfyOmGeneratorServiceProvider.php
+++ b/src/InfyOmGeneratorServiceProvider.php
@@ -3,6 +3,7 @@
 namespace InfyOm\Generator;
 
 use Illuminate\Support\ServiceProvider;
+
 use InfyOm\Generator\Commands\API\APIControllerGeneratorCommand;
 use InfyOm\Generator\Commands\API\APIGeneratorCommand;
 use InfyOm\Generator\Commands\API\APIRequestsGeneratorCommand;
@@ -31,7 +32,7 @@ class InfyOmGeneratorServiceProvider extends ServiceProvider
     public function boot()
     {
         if ($this->app->runningInConsole()) {
-            $configPath = __DIR__.'/../config/laravel_generator.php';
+            $configPath = __DIR__ . '/../config/laravel_generator.php';
             $this->publishes([
                 $configPath => config_path('infyom/laravel_generator.php'),
             ]);
@@ -45,7 +46,7 @@ class InfyOmGeneratorServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->mergeConfigFrom(__DIR__.'/../config/laravel_generator.php', 'infyom.laravel_generator');
+        $this->mergeConfigFrom(__DIR__ . '/../config/laravel_generator.php', 'infyom.laravel_generator');
 
         $this->app->singleton('infyom.publish', function ($app) {
             return new GeneratorPublishCommand();

--- a/src/Request/APIRequest.php
+++ b/src/Request/APIRequest.php
@@ -5,7 +5,7 @@ namespace InfyOm\Generator\Request;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Arr;
 use InfyOm\Generator\Utils\ResponseUtil;
-use Response;
+use Illuminate\Http\Response;
 
 class APIRequest extends FormRequest
 {

--- a/src/Request/APIRequest.php
+++ b/src/Request/APIRequest.php
@@ -2,10 +2,11 @@
 
 namespace InfyOm\Generator\Request;
 
-use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Support\Arr;
-use InfyOm\Generator\Utils\ResponseUtil;
 use Illuminate\Http\Response;
+use Illuminate\Foundation\Http\FormRequest;
+
+use InfyOm\Generator\Utils\ResponseUtil;
 
 class APIRequest extends FormRequest
 {

--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -2,10 +2,12 @@
 
 namespace InfyOm\Generator\Utils;
 
-use DB;
+use Illuminate\Support\Str;
+use Illuminate\Support\Facades\DB;
+
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
-use Illuminate\Support\Str;
+
 use InfyOm\Generator\Common\GeneratorField;
 use InfyOm\Generator\Common\GeneratorFieldRelation;
 
@@ -275,7 +277,7 @@ class TableFieldsGenerator
     {
         $field = new GeneratorField();
         $field->name = $column->getName();
-        $field->parseDBType($dbType.','.$column->getPrecision().','.$column->getScale());
+        $field->parseDBType($dbType . ',' . $column->getPrecision() . ',' . $column->getScale());
         $field->htmlType = 'number';
 
         if ($dbType === 'decimal') {
@@ -377,7 +379,7 @@ class TableFieldsGenerator
                     $isOneToOne = $this->isOneToOne($primary, $foreignKey, $modelTable->primaryKey);
                     if ($isOneToOne) {
                         $modelName = model_name_from_table_name($tableName);
-                        $this->relations[] = GeneratorFieldRelation::parseRelation('1t1,'.$modelName);
+                        $this->relations[] = GeneratorFieldRelation::parseRelation('1t1,' . $modelName);
                         continue;
                     }
 
@@ -386,7 +388,7 @@ class TableFieldsGenerator
                     if ($isOneToMany) {
                         $modelName = model_name_from_table_name($tableName);
                         $this->relations[] = GeneratorFieldRelation::parseRelation(
-                            '1tm,'.$modelName.','.$foreignKey->localField
+                            '1tm,' . $modelName . ',' . $foreignKey->localField
                         );
                         continue;
                     }
@@ -466,7 +468,7 @@ class TableFieldsGenerator
 
         $modelName = model_name_from_table_name($manyToManyTable);
 
-        return GeneratorFieldRelation::parseRelation('mtm,'.$modelName.','.$tableName);
+        return GeneratorFieldRelation::parseRelation('mtm,' . $modelName . ',' . $tableName);
     }
 
     /**
@@ -539,7 +541,7 @@ class TableFieldsGenerator
             if ($foreignField == $tables[$foreignTable]->primaryKey) {
                 $modelName = model_name_from_table_name($foreignTable);
                 $manyToOneRelations[] = GeneratorFieldRelation::parseRelation(
-                    'mt1,'.$modelName.','.$foreignKey->localField
+                    'mt1,' . $modelName . ',' . $foreignKey->localField
                 );
             }
         }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Str;
+
 use InfyOm\Generator\Common\GeneratorField;
 
 if (!function_exists('infy_tab')) {
@@ -72,7 +73,7 @@ if (!function_exists('infy_nl_tab')) {
      */
     function infy_nl_tab($lns = 1, $tabs = 1)
     {
-        return infy_nls($lns).infy_tabs($tabs);
+        return infy_nls($lns) . infy_tabs($tabs);
     }
 }
 
@@ -94,13 +95,13 @@ if (!function_exists('get_template_file_path')) {
             resource_path('infyom/infyom-generator-templates/')
         );
 
-        $path = $templatesPath.$templateName.'.stub';
+        $path = $templatesPath . $templateName . '.stub';
 
         if (file_exists($path)) {
             return $path;
         }
 
-        return get_templates_package_path($templateType).'/templates/'.$templateName.'.stub';
+        return get_templates_package_path($templateType) . '/templates/' . $templateName . '.stub';
     }
 }
 
@@ -115,7 +116,7 @@ if (!function_exists('get_templates_package_path')) {
     function get_templates_package_path($templateType)
     {
         if (strpos($templateType, '/') === false) {
-            $templateType = base_path('vendor/infyomlabs/').$templateType;
+            $templateType = base_path('vendor/infyomlabs/') . $templateType;
         }
 
         return $templateType;

--- a/templates/api/controller/api_controller.stub
+++ b/templates/api/controller/api_controller.stub
@@ -2,13 +2,15 @@
 
 namespace $NAMESPACE_API_CONTROLLER$;
 
-use $NAMESPACE_API_REQUEST$\Create$MODEL_NAME$APIRequest;
-use $NAMESPACE_API_REQUEST$\Update$MODEL_NAME$APIRequest;
+use Illuminate\Http\Response;
+use Illuminate\Http\Request;
+
 use $NAMESPACE_MODEL$\$MODEL_NAME$;
 use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
-use Illuminate\Http\Request;
+use $NAMESPACE_API_REQUEST$\Create$MODEL_NAME$APIRequest;
+use $NAMESPACE_API_REQUEST$\Update$MODEL_NAME$APIRequest;
+
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use Response;
 
 $DOC_CONTROLLER$
 class $MODEL_NAME$APIController extends AppBaseController

--- a/templates/api/controller/api_controller_locale.stub
+++ b/templates/api/controller/api_controller_locale.stub
@@ -2,13 +2,15 @@
 
 namespace $NAMESPACE_API_CONTROLLER$;
 
-use $NAMESPACE_API_REQUEST$\Create$MODEL_NAME$APIRequest;
-use $NAMESPACE_API_REQUEST$\Update$MODEL_NAME$APIRequest;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
 use $NAMESPACE_MODEL$\$MODEL_NAME$;
 use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
-use Illuminate\Http\Request;
+use $NAMESPACE_API_REQUEST$\Create$MODEL_NAME$APIRequest;
+use $NAMESPACE_API_REQUEST$\Update$MODEL_NAME$APIRequest;
+
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use Response;
 
 $DOC_CONTROLLER$
 class $MODEL_NAME$APIController extends AppBaseController

--- a/templates/api/controller/api_controller_locale_resource.stub
+++ b/templates/api/controller/api_controller_locale_resource.stub
@@ -2,14 +2,16 @@
 
 namespace $NAMESPACE_API_CONTROLLER$;
 
-use $NAMESPACE_API_REQUEST$\Create$MODEL_NAME$APIRequest;
-use $NAMESPACE_API_REQUEST$\Update$MODEL_NAME$APIRequest;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
 use $NAMESPACE_MODEL$\$MODEL_NAME$;
 use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
-use Illuminate\Http\Request;
-use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
 use $NAMESPACE_API_RESOURCE$\$MODEL_NAME$Resource;
-use Response;
+use $NAMESPACE_API_REQUEST$\Create$MODEL_NAME$APIRequest;
+use $NAMESPACE_API_REQUEST$\Update$MODEL_NAME$APIRequest;
+
+use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
 
 $DOC_CONTROLLER$
 class $MODEL_NAME$APIController extends AppBaseController

--- a/templates/api/controller/api_controller_resource.stub
+++ b/templates/api/controller/api_controller_resource.stub
@@ -2,14 +2,16 @@
 
 namespace $NAMESPACE_API_CONTROLLER$;
 
-use $NAMESPACE_API_REQUEST$\Create$MODEL_NAME$APIRequest;
-use $NAMESPACE_API_REQUEST$\Update$MODEL_NAME$APIRequest;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
 use $NAMESPACE_MODEL$\$MODEL_NAME$;
 use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
-use Illuminate\Http\Request;
-use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
 use $NAMESPACE_API_RESOURCE$\$MODEL_NAME$Resource;
-use Response;
+use $NAMESPACE_API_REQUEST$\Create$MODEL_NAME$APIRequest;
+use $NAMESPACE_API_REQUEST$\Update$MODEL_NAME$APIRequest;
+
+use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
 
 $DOC_CONTROLLER$
 class $MODEL_NAME$APIController extends AppBaseController

--- a/templates/api/controller/model_api_controller.stub
+++ b/templates/api/controller/model_api_controller.stub
@@ -2,12 +2,14 @@
 
 namespace $NAMESPACE_API_CONTROLLER$;
 
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
 use $NAMESPACE_API_REQUEST$\Create$MODEL_NAME$APIRequest;
 use $NAMESPACE_API_REQUEST$\Update$MODEL_NAME$APIRequest;
 use $NAMESPACE_MODEL$\$MODEL_NAME$;
-use Illuminate\Http\Request;
+
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use Response;
 
 $DOC_CONTROLLER$
 class $MODEL_NAME$APIController extends AppBaseController

--- a/templates/api/controller/model_api_controller_locale.stub
+++ b/templates/api/controller/model_api_controller_locale.stub
@@ -2,12 +2,14 @@
 
 namespace $NAMESPACE_API_CONTROLLER$;
 
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+use $NAMESPACE_MODEL$\$MODEL_NAME$;
 use $NAMESPACE_API_REQUEST$\Create$MODEL_NAME$APIRequest;
 use $NAMESPACE_API_REQUEST$\Update$MODEL_NAME$APIRequest;
-use $NAMESPACE_MODEL$\$MODEL_NAME$;
-use Illuminate\Http\Request;
+
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use Response;
 
 $DOC_CONTROLLER$
 class $MODEL_NAME$APIController extends AppBaseController

--- a/templates/api/controller/model_api_controller_locale_resource.stub
+++ b/templates/api/controller/model_api_controller_locale_resource.stub
@@ -2,13 +2,15 @@
 
 namespace $NAMESPACE_API_CONTROLLER$;
 
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+use $NAMESPACE_MODEL$\$MODEL_NAME$;
+use $NAMESPACE_API_RESOURCE$\$MODEL_NAME$Resource;
 use $NAMESPACE_API_REQUEST$\Create$MODEL_NAME$APIRequest;
 use $NAMESPACE_API_REQUEST$\Update$MODEL_NAME$APIRequest;
-use $NAMESPACE_MODEL$\$MODEL_NAME$;
-use Illuminate\Http\Request;
+
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use $NAMESPACE_API_RESOURCE$\$MODEL_NAME$Resource;
-use Response;
 
 $DOC_CONTROLLER$
 class $MODEL_NAME$APIController extends AppBaseController

--- a/templates/api/controller/model_api_controller_resource.stub
+++ b/templates/api/controller/model_api_controller_resource.stub
@@ -2,13 +2,15 @@
 
 namespace $NAMESPACE_API_CONTROLLER$;
 
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+use $NAMESPACE_MODEL$\$MODEL_NAME$;
+use $NAMESPACE_API_RESOURCE$\$MODEL_NAME$Resource;
 use $NAMESPACE_API_REQUEST$\Create$MODEL_NAME$APIRequest;
 use $NAMESPACE_API_REQUEST$\Update$MODEL_NAME$APIRequest;
-use $NAMESPACE_MODEL$\$MODEL_NAME$;
-use Illuminate\Http\Request;
+
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use $NAMESPACE_API_RESOURCE$\$MODEL_NAME$Resource;
-use Response;
 
 $DOC_CONTROLLER$
 class $MODEL_NAME$APIController extends AppBaseController

--- a/templates/api/test/api_test.stub
+++ b/templates/api/test/api_test.stub
@@ -2,6 +2,7 @@
 
 use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+
 use $NAMESPACE_TESTS$\TestCase;
 use $NAMESPACE_TESTS$\ApiTestTrait;
 use $NAMESPACE_MODEL$\$MODEL_NAME$;

--- a/templates/app_base_controller.stub
+++ b/templates/app_base_controller.stub
@@ -2,8 +2,9 @@
 
 namespace $NAMESPACE_APP$\Http\Controllers;
 
+use Illuminate\Http\Response;
+
 use InfyOm\Generator\Utils\ResponseUtil;
-use Response;
 
 /**
  * @OA\Server(url="/$API_PREFIX$")

--- a/templates/base_repository.stub
+++ b/templates/base_repository.stub
@@ -4,7 +4,6 @@ namespace $NAMESPACE_APP$\Repositories;
 
 use Illuminate\Database\Eloquent\Model;
 
-
 abstract class BaseRepository
 {
     /**

--- a/templates/factories/model_factory.stub
+++ b/templates/factories/model_factory.stub
@@ -2,8 +2,9 @@
 
 namespace $NAMESPACE_FACTORY$;
 
-use $NAMESPACE_MODEL$\$MODEL_NAME$;
 use Illuminate\Database\Eloquent\Factories\Factory;
+
+use $NAMESPACE_MODEL$\$MODEL_NAME$;
 $RELATION_USES$
 
 class $MODEL_NAME$Factory extends Factory

--- a/templates/migration.stub
+++ b/templates/migration.stub
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Database\Migrations\Migration;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
 
 class Create$TABLE_NAME_TITLE$Table extends Migration
 {

--- a/templates/model/model.stub
+++ b/templates/model/model.stub
@@ -3,6 +3,7 @@
 namespace $NAMESPACE_MODEL$;
 
 use Illuminate\Database\Eloquent\Model;
+
 $SOFT_DELETE_IMPORT$
 $HAS_FACTORY_IMPORT$
 

--- a/templates/scaffold/controller/controller.stub
+++ b/templates/scaffold/controller/controller.stub
@@ -2,13 +2,16 @@
 
 namespace $NAMESPACE_CONTROLLER$;
 
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+use Laracasts\Flash\Flash;
+
 use $NAMESPACE_REQUEST$\Create$MODEL_NAME$Request;
 use $NAMESPACE_REQUEST$\Update$MODEL_NAME$Request;
 use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
+
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use Illuminate\Http\Request;
-use Flash;
-use Response;
 
 class $MODEL_NAME$Controller extends AppBaseController
 {

--- a/templates/scaffold/controller/controller_locale.stub
+++ b/templates/scaffold/controller/controller_locale.stub
@@ -2,13 +2,15 @@
 
 namespace $NAMESPACE_CONTROLLER$;
 
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+use Laracasts\Flash\Flash;
+
 use $NAMESPACE_REQUEST$\Create$MODEL_NAME$Request;
 use $NAMESPACE_REQUEST$\Update$MODEL_NAME$Request;
 use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use Illuminate\Http\Request;
-use Flash;
-use Response;
 
 class $MODEL_NAME$Controller extends AppBaseController
 {

--- a/templates/scaffold/controller/datatable_controller.stub
+++ b/templates/scaffold/controller/datatable_controller.stub
@@ -2,14 +2,17 @@
 
 namespace $NAMESPACE_CONTROLLER$;
 
-use $NAMESPACE_DATATABLES$\$MODEL_NAME$DataTable;
+use Illuminate\Http\Response;
+
+use Laracasts\Flash\Flash;
+
 use $NAMESPACE_REQUEST$;
+use $NAMESPACE_DATATABLES$\$MODEL_NAME$DataTable;
 use $NAMESPACE_REQUEST$\Create$MODEL_NAME$Request;
 use $NAMESPACE_REQUEST$\Update$MODEL_NAME$Request;
 use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
-use Flash;
+
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use Response;
 
 class $MODEL_NAME$Controller extends AppBaseController
 {

--- a/templates/scaffold/controller/datatable_controller_locale.stub
+++ b/templates/scaffold/controller/datatable_controller_locale.stub
@@ -2,14 +2,17 @@
 
 namespace $NAMESPACE_CONTROLLER$;
 
-use $NAMESPACE_DATATABLES$\$MODEL_NAME$DataTable;
+use Illuminate\Http\Response;
+
+use Laracasts\Flash\Flash;
+
 use $NAMESPACE_REQUEST$;
+use $NAMESPACE_DATATABLES$\$MODEL_NAME$DataTable;
+use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
 use $NAMESPACE_REQUEST$\Create$MODEL_NAME$Request;
 use $NAMESPACE_REQUEST$\Update$MODEL_NAME$Request;
-use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
-use Flash;
+
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use Response;
 
 class $MODEL_NAME$Controller extends AppBaseController
 {

--- a/templates/scaffold/controller/jquery_datatable_controller.stub
+++ b/templates/scaffold/controller/jquery_datatable_controller.stub
@@ -2,16 +2,20 @@
 
 namespace $NAMESPACE_CONTROLLER$;
 
-use $NAMESPACE_DATATABLES$\$MODEL_NAME$DataTable;
-use $NAMESPACE_REQUEST$;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+use Laracasts\Flash\Flash;
+
+use Datatables;
+
+use $NAMESPACE_REQUEST$;
+use $NAMESPACE_DATATABLES$\$MODEL_NAME$DataTable;
 use $NAMESPACE_REQUEST$\Create$MODEL_NAME$Request;
 use $NAMESPACE_REQUEST$\Update$MODEL_NAME$Request;
 use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
-use Flash;
+
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use Response;
-use Datatables;
 
 class $MODEL_NAME$Controller extends AppBaseController
 {

--- a/templates/scaffold/controller/model_controller.stub
+++ b/templates/scaffold/controller/model_controller.stub
@@ -2,13 +2,16 @@
 
 namespace $NAMESPACE_CONTROLLER$;
 
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+use Laracasts\Flash\Flash;
+
+use $NAMESPACE_MODEL$\$MODEL_NAME$;
 use $NAMESPACE_REQUEST$\Create$MODEL_NAME$Request;
 use $NAMESPACE_REQUEST$\Update$MODEL_NAME$Request;
+
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use $NAMESPACE_MODEL$\$MODEL_NAME$;
-use Illuminate\Http\Request;
-use Flash;
-use Response;
 
 class $MODEL_NAME$Controller extends AppBaseController
 {

--- a/templates/scaffold/controller/model_controller_locale.stub
+++ b/templates/scaffold/controller/model_controller_locale.stub
@@ -2,13 +2,16 @@
 
 namespace $NAMESPACE_CONTROLLER$;
 
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+
+use Laracasts\Flash\Flash;
+
+use $NAMESPACE_MODEL$\$MODEL_NAME$;
 use $NAMESPACE_REQUEST$\Create$MODEL_NAME$Request;
 use $NAMESPACE_REQUEST$\Update$MODEL_NAME$Request;
+
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use $NAMESPACE_MODEL$\$MODEL_NAME$;
-use Illuminate\Http\Request;
-use Flash;
-use Response;
 
 class $MODEL_NAME$Controller extends AppBaseController
 {

--- a/templates/scaffold/controller/model_datatable_controller.stub
+++ b/templates/scaffold/controller/model_datatable_controller.stub
@@ -2,14 +2,17 @@
 
 namespace $NAMESPACE_CONTROLLER$;
 
-use $NAMESPACE_DATATABLES$\$MODEL_NAME$DataTable;
+use Illuminate\Http\Response;
+
+use Laracasts\Flash\Flash;
+
 use $NAMESPACE_REQUEST$;
+use $NAMESPACE_MODEL$\$MODEL_NAME$;
+use $NAMESPACE_DATATABLES$\$MODEL_NAME$DataTable;
 use $NAMESPACE_REQUEST$\Create$MODEL_NAME$Request;
 use $NAMESPACE_REQUEST$\Update$MODEL_NAME$Request;
-use $NAMESPACE_MODEL$\$MODEL_NAME$;
-use Flash;
+
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use Response;
 
 class $MODEL_NAME$Controller extends AppBaseController
 {

--- a/templates/scaffold/controller/model_datatable_controller_locale.stub
+++ b/templates/scaffold/controller/model_datatable_controller_locale.stub
@@ -2,14 +2,17 @@
 
 namespace $NAMESPACE_CONTROLLER$;
 
-use $NAMESPACE_DATATABLES$\$MODEL_NAME$DataTable;
+use Illuminate\Http\Response;
+
+use Laracasts\Flash\Flash;
+
 use $NAMESPACE_REQUEST$;
+use $NAMESPACE_MODEL$\$MODEL_NAME$;
+use $NAMESPACE_DATATABLES$\$MODEL_NAME$DataTable;
 use $NAMESPACE_REQUEST$\Create$MODEL_NAME$Request;
 use $NAMESPACE_REQUEST$\Update$MODEL_NAME$Request;
-use $NAMESPACE_MODEL$\$MODEL_NAME$;
-use Flash;
+
 use $NAMESPACE_APP$\Http\Controllers\AppBaseController;
-use Response;
 
 class $MODEL_NAME$Controller extends AppBaseController
 {

--- a/templates/scaffold/datatable.stub
+++ b/templates/scaffold/datatable.stub
@@ -3,6 +3,7 @@
 namespace $NAMESPACE_DATATABLES$;
 
 use $NAMESPACE_MODEL$\$MODEL_NAME$;
+
 use Yajra\DataTables\Services\DataTable;
 use Yajra\DataTables\EloquentDataTable;
 

--- a/templates/scaffold/datatable_locale.stub
+++ b/templates/scaffold/datatable_locale.stub
@@ -3,6 +3,7 @@
 namespace $NAMESPACE_DATATABLES$;
 
 use $NAMESPACE_MODEL$\$MODEL_NAME$;
+
 use Yajra\DataTables\Services\DataTable;
 use Yajra\DataTables\EloquentDataTable;
 use Yajra\DataTables\Html\Column;

--- a/templates/scaffold/request/create_request.stub
+++ b/templates/scaffold/request/create_request.stub
@@ -3,6 +3,7 @@
 namespace $NAMESPACE_REQUEST$;
 
 use Illuminate\Foundation\Http\FormRequest;
+
 use $NAMESPACE_MODEL$\$MODEL_NAME$;
 
 class Create$MODEL_NAME$Request extends FormRequest

--- a/templates/scaffold/request/update_request.stub
+++ b/templates/scaffold/request/update_request.stub
@@ -3,6 +3,7 @@
 namespace $NAMESPACE_REQUEST$;
 
 use Illuminate\Foundation\Http\FormRequest;
+
 use $NAMESPACE_MODEL$\$MODEL_NAME$;
 
 class Update$MODEL_NAME$Request extends FormRequest

--- a/templates/test/repository_test.stub
+++ b/templates/test/repository_test.stub
@@ -1,8 +1,9 @@
 <?php namespace $NAMESPACE_REPOSITORIES_TESTS$;
 
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
 use $NAMESPACE_MODEL$\$MODEL_NAME$;
 use $NAMESPACE_REPOSITORY$\$MODEL_NAME$Repository;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
 use $NAMESPACE_TESTS$\TestCase;
 use $NAMESPACE_TESTS$\ApiTestTrait;
 

--- a/templates/user/user_controller.stub
+++ b/templates/user/user_controller.stub
@@ -2,14 +2,16 @@
 
 namespace $NAMESPACE_CONTROLLER$;
 
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Hash;
+
+use Laracasts\Flash\Flash;
+
 use $NAMESPACE_REQUEST$\CreateUserRequest;
 use $NAMESPACE_REQUEST$\UpdateUserRequest;
 use $NAMESPACE_REPOSITORY$\UserRepository;
 use $NAMESPACE_CONTROLLER$\AppBaseController;
-use Illuminate\Http\Request;
-use Flash;
-use Response;
-use Hash;
 
 class UserController extends AppBaseController
 {

--- a/templates/user/user_controller_without_repository.stub
+++ b/templates/user/user_controller_without_repository.stub
@@ -2,14 +2,17 @@
 
 namespace $NAMESPACE_CONTROLLER$;
 
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Hash;
+
+use Laracasts\Flash\Flash;
+
 use $NAMESPACE_REQUEST$\CreateUserRequest;
 use $NAMESPACE_REQUEST$\UpdateUserRequest;
 use $NAMESPACE_CONTROLLER$\AppBaseController;
-use Illuminate\Http\Request;
-use Flash;
-use Response;
-use Hash;
 use $NAMESPACE_USER$;
+
 class UserController extends AppBaseController
 {
     /**

--- a/templates/view_service_provider.stub
+++ b/templates/view_service_provider.stub
@@ -2,8 +2,9 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\ServiceProvider;
 use View;
+
+use Illuminate\Support\ServiceProvider;
 
 class ViewServiceProvider extends ServiceProvider
 {


### PR DESCRIPTION
If there are many files current namespaces are not readable (my opinion). Also, I can't see the alias references on VS Code. So I reordered, groped, and converted some namespaces to long versions.

These commits may not be necessary but grouped and ordered namespaces helps to review and debug.

My namespace organization structure;

[1] `use Exception;` - PHP native namespaces
[2] `use Illumunate\...`  - Laravel native namespaces
[3] `use Symfony\...`  - Symfony native namespaces
[4] `use InfyOm\...`  - Symfony native namespaces