### PR TITLE
Fix migration-genaration dbType without ":"

### DIFF
--- a/src/Common/GeneratorField.php
+++ b/src/Common/GeneratorField.php
@@ -32,13 +32,6 @@ class GeneratorField
 
     public function parseDBType(string $dbInput)
     {
-        if (!Str::contains($dbInput, ':')) {
-            $this->dbType = $dbInput;
-            $this->prepareMigrationText();
-
-            return;
-        }
-
         $dbInputArr = explode(':', $dbInput);
         $dbType = (string) array_shift($dbInputArr);
 


### PR DESCRIPTION
fixed migration-generation issue, with dbType does not include ":".
fix #1043 .