### PR TITLE
Always add max: validation to string type fields.

### DIFF
--- a/src/Common/GeneratorField.php
+++ b/src/Common/GeneratorField.php
@@ -29,6 +29,8 @@ class GeneratorField
     public string $foreignKeyText = '';
 
     public int $numberDecimalPoints = 2;
+    /** @var \Doctrine\DBAL\Schema\Column */
+    public $fieldDetails = null;
 
     public function parseDBType(string $dbInput)
     {

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -204,7 +204,7 @@ class ModelGenerator extends BaseGenerator
 
                             // Enforce a maximum string length if possible.
                             if ((int) $field->fieldDetails->getLength() > 0) {
-                                $rule[] = 'max:' . $field->fieldDetails->getLength();
+                                $rule[] = 'max:'.$field->fieldDetails->getLength();
                             }
                             break;
                     }

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -203,7 +203,7 @@ class ModelGenerator extends BaseGenerator
                             $rule[] = 'string';
 
                             // Enforce a maximum string length if possible.
-                            if((int) $field->fieldDetails->getLength() > 0) {
+                            if ((int) $field->fieldDetails->getLength() > 0) {
                                 $rule[] = 'max:' . $field->fieldDetails->getLength();
                             }
                             break;

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -203,7 +203,7 @@ class ModelGenerator extends BaseGenerator
                             $rule[] = 'string';
 
                             // Enforce a maximum string length if possible.
-                            if((int)$field->fieldDetails->getLength() > 0) {
+                            if((int) $field->fieldDetails->getLength() > 0) {
                                 $rule[] = 'max:' . $field->fieldDetails->getLength();
                             }
                             break;

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -199,17 +199,13 @@ class ModelGenerator extends BaseGenerator
                             $rule[] = 'numeric';
                             break;
                         case 'string':
+                        case 'text':
                             $rule[] = 'string';
 
                             // Enforce a maximum string length if possible.
-                            foreach (explode(':', $field->dbType) as $key => $value) {
-                                if (preg_match('/string,(\d+)/', $value, $matches)) {
-                                    $rule[] = 'max:'.$matches[1];
-                                }
+                            if((int)$field->fieldDetails->getLength() > 0) {
+                                $rule[] = 'max:' . $field->fieldDetails->getLength();
                             }
-                            break;
-                        case 'text':
-                            $rule[] = 'string';
                             break;
                     }
 

--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -56,6 +56,9 @@ class TableFieldsGenerator
     /** @var array */
     public $ignoredFields;
 
+    /** @var \Doctrine\DBAL\Schema\Table */
+    public $tableDetails;
+
     public function __construct($tableName, $ignoredFields, $connection = '')
     {
         $this->tableName = $tableName;
@@ -73,6 +76,8 @@ class TableFieldsGenerator
             'json' => 'text',
             'bit'  => 'boolean',
         ];
+
+        $this->tableDetails = $this->schemaManager->listTableDetails($this->tableName);
 
         $mappings = config('laravel_generator.from_table.doctrine_mappings', []);
         $mappings = array_merge($mappings, $defaultMappings);
@@ -254,6 +259,7 @@ class TableFieldsGenerator
     {
         $field = new GeneratorField();
         $field->name = $column->getName();
+        $field->fieldDetails = $this->tableDetails->getColumn($field->name);
         $field->parseDBType($dbType); //, $column); TODO: handle column param
         $field->parseHtmlInput($htmlType);
 

--- a/views/model/model.blade.php
+++ b/views/model/model.blade.php
@@ -29,7 +29,7 @@ class {{ $config->modelNames->name }} extends Model
         {!! $casts !!}
     ];
 
-    public static $rules = [
+    public static array $rules = [
         {!! $rules !!}
     ];
 


### PR DESCRIPTION
Is there some reason not to? Forms in views should also always set these to input fields.