### PR TITLE
Make `config` variable available only in infyom view files

### DIFF
--- a/src/InfyOmGeneratorServiceProvider.php
+++ b/src/InfyOmGeneratorServiceProvider.php
@@ -62,7 +62,7 @@ class InfyOmGeneratorServiceProvider extends ServiceProvider
         $this->registerCommands();
         $this->loadViewsFrom(__DIR__.'/../views', 'laravel-generator');
 
-        View::composer('*', function ($view) {
+        View::composer('laravel-generator::*', function ($view) {
             $view->with(['config' => app(GeneratorConfig::class)]);
         });
 

--- a/src/InfyOmGeneratorServiceProvider.php
+++ b/src/InfyOmGeneratorServiceProvider.php
@@ -62,9 +62,11 @@ class InfyOmGeneratorServiceProvider extends ServiceProvider
         $this->registerCommands();
         $this->loadViewsFrom(__DIR__.'/../views', 'laravel-generator');
 
-        View::composer('laravel-generator::*', function ($view) {
-            $view->with(['config' => app(GeneratorConfig::class)]);
-        });
+        foreach (['laravel-generator', 'adminlte-templates'] as $packageName) {
+            View::composer($packageName.'::*', function ($view) {
+                $view->with(['config' => app(GeneratorConfig::class)]);
+            });
+        }
 
         Blade::directive('tab', function () {
             return '<?php echo infy_tab() ?>';


### PR DESCRIPTION
After upgrade to laravel 10 and upgrading this library we noticed that every `$config` variable that we use in our blade files now suddenly has type of `InfyOm\Generator\Common\GeneratorConfig` instead of being something we want it to be. 

After some research we found [THIS COMMIT](https://github.com/InfyOmLabs/laravel-generator/commit/fbdb677ed99919051be31491c20409aea623a7af) that registers `$config` for every view. 

**So expected behaviour is this** (please note, myveiw.blade.php is not related to laravel-generator in any way):
```
// controller
return view('myview', ['config' => ['key' => 'value']]); // pass $config variable to myview.blade.php

// myview.blade.php
$config['key'] == 'value' // true
```

**actual behaviour**:
```
// controller
return view('myview', ['config' => ['key' => 'value']]); // pass $config variable to myview.blade.php

// myview.blade.php
$config['key'] == 'value' // false. Moreover $config is InfyOm\Generator\Common\GeneratorConfig.
```

This PR makes `$config`  variable available for laravel-generator's views **only**. 

@mitulgolakiya could you please help me to make sure it's valid change that doesn't break what was intended initially with that commit.

Thanks! 
