### PR TITLE
L11 compability without doctrine

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,18 +23,18 @@
     }],
     "require": {
         "php": "^8.1.0",
-        "illuminate/support": "^10.0",
-        "illuminate/console": "^10.0",
+        "illuminate/support": "^10.0|^11.0",
+        "illuminate/console": "^10.0|^11.0",
         "laracasts/flash": "^3.2.2",
         "laravelcollective/html": "^6.4",
-        "symfony/var-exporter": "^6.2.5"
+        "symfony/var-exporter": "^6.2.5|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^10.0.7",
         "mockery/mockery": "^1.5.1",
-        "orchestra/testbench": "^8.0.0",
-        "pestphp/pest": "2.x-dev",
-        "pestphp/pest-plugin-laravel": "2.x-dev"
+        "orchestra/testbench": "^8.0.0|^9.0",
+        "pestphp/pest": "2.x-dev|^2.34",
+        "pestphp/pest-plugin-laravel": "2.x-dev|^2.3"
     },
     "autoload": {
         "psr-4": {

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -204,7 +204,7 @@ class ModelGenerator extends BaseGenerator
 
                             // Enforce a maximum string length if possible.
 
-                    $length = get_field_length($field->fieldDetails['type']);
+                            $length = get_field_length($field->fieldDetails['type']);
                             if ((int) $length > 1) {
                                 $rule[] = 'max:'.$length;
                             }

--- a/src/Generators/ModelGenerator.php
+++ b/src/Generators/ModelGenerator.php
@@ -203,8 +203,10 @@ class ModelGenerator extends BaseGenerator
                             $rule[] = 'string';
 
                             // Enforce a maximum string length if possible.
-                            if ((int) $field->fieldDetails->getLength() > 0) {
-                                $rule[] = 'max:'.$field->fieldDetails->getLength();
+
+                    $length = get_field_length($field->fieldDetails['type']);
+                            if ((int) $length > 1) {
+                                $rule[] = 'max:'.$length;
                             }
                             break;
                     }

--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -2,7 +2,6 @@
 
 namespace InfyOm\Generator\Utils;
 
-use DB;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
 use Illuminate\Support\Facades\Schema;
@@ -266,7 +265,7 @@ class TableFieldsGenerator
         $field = new GeneratorField();
         $field->name = $column['name'];
         $length = get_field_length($column['type']);
-        $field->parseDBType($dbType . ',' . get_field_precision($length) . ',' . get_field_scale($length));
+        $field->parseDBType($dbType.','.get_field_precision($length).','.get_field_scale($length));
         $field->htmlType = 'number';
 
         if ($dbType === 'decimal') {

--- a/src/Utils/TableFieldsGenerator.php
+++ b/src/Utils/TableFieldsGenerator.php
@@ -5,7 +5,9 @@ namespace InfyOm\Generator\Utils;
 use DB;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use InfyOm\Generator\Common\GeneratorConfig;
 use InfyOm\Generator\Common\GeneratorField;
 use InfyOm\Generator\Common\GeneratorFieldRelation;
 
@@ -59,39 +61,17 @@ class TableFieldsGenerator
     /** @var \Doctrine\DBAL\Schema\Table */
     public $tableDetails;
 
+    public GeneratorConfig $config;
+
     public function __construct($tableName, $ignoredFields, $connection = '')
     {
         $this->tableName = $tableName;
         $this->ignoredFields = $ignoredFields;
 
-        if (!empty($connection)) {
-            $this->schemaManager = DB::connection($connection)->getDoctrineSchemaManager();
-        } else {
-            $this->schemaManager = DB::getDoctrineSchemaManager();
-        }
-
-        $platform = $this->schemaManager->getDatabasePlatform();
-        $defaultMappings = [
-            'enum' => 'string',
-            'json' => 'text',
-            'bit'  => 'boolean',
-        ];
-
-//        $this->tableDetails = $this->schemaManager->listTableDetails($this->tableName);
-
-        $mappings = config('laravel_generator.from_table.doctrine_mappings', []);
-        $mappings = array_merge($mappings, $defaultMappings);
-        foreach ($mappings as $dbType => $doctrineType) {
-            $platform->registerDoctrineTypeMapping($dbType, $doctrineType);
-        }
-        // Added
-        $this->tableDetails = $this->schemaManager->listTableDetails($this->tableName);
-
-        $columns = $this->schemaManager->listTableColumns($tableName);
-
+        $columns = Schema::getColumns($tableName);
         $this->columns = [];
         foreach ($columns as $column) {
-            if (!in_array($column->getName(), $ignoredFields)) {
+            if (!in_array($column['name'], $ignoredFields)) {
                 $this->columns[] = $column;
             }
         }
@@ -107,7 +87,7 @@ class TableFieldsGenerator
     public function prepareFieldsFromTable()
     {
         foreach ($this->columns as $column) {
-            $type = $column->getType()->getName();
+            $type = $column['type_name'];
 
             switch ($type) {
                 case 'integer':
@@ -120,7 +100,7 @@ class TableFieldsGenerator
                     $field = $this->generateIntFieldInput($column, 'bigInteger');
                     break;
                 case 'boolean':
-                    $name = Str::title(str_replace('_', ' ', $column->getName()));
+                    $name = Str::title(str_replace('_', ' ', $column['name']));
                     $field = $this->generateField($column, 'boolean', 'checkbox');
                     break;
                 case 'datetime':
@@ -160,8 +140,8 @@ class TableFieldsGenerator
                 $field->inIndex = false;
                 $field->inView = false;
             }
-            $field->isNotNull = $column->getNotNull();
-            $field->description = $column->getComment() ?? ''; // get comments from table
+            $field->isNotNull = !$column['nullable'];
+            $field->description = $column['comment'] ?? ''; // get comments from table
 
             $this->fields[] = $field;
         }
@@ -176,9 +156,14 @@ class TableFieldsGenerator
      */
     public function getPrimaryKeyOfTable($tableName)
     {
-        $column = $this->schemaManager->listTableDetails($tableName)->getPrimaryKey();
+        $column = '';
+        foreach (Schema::getIndexes($tableName) as $index) {
+            if ($index['primary']) {
+                $column = $index['columns'][0];
+            }
+        }
 
-        return $column ? $column->getColumns()[0] : '';
+        return $column;
     }
 
     /**
@@ -210,17 +195,17 @@ class TableFieldsGenerator
     private function generateIntFieldInput($column, $dbType)
     {
         $field = new GeneratorField();
-        $field->name = $column->getName();
+        $field->name = $column['name'];
         $field->parseDBType($dbType);
         $field->htmlType = 'number';
 
-        if ($column->getAutoincrement()) {
+        if ($column['auto_increment']) {
             $field->dbType .= ',true';
         } else {
             $field->dbType .= ',false';
         }
 
-        if ($column->getUnsigned()) {
+        if (str_contains($column['type'], 'unsigned')) {
             $field->dbType .= ',true';
         }
 
@@ -260,8 +245,8 @@ class TableFieldsGenerator
     private function generateField($column, $dbType, $htmlType)
     {
         $field = new GeneratorField();
-        $field->name = $column->getName();
-        $field->fieldDetails = $this->tableDetails->getColumn($field->name);
+        $field->name = $column['name'];
+        $field->fieldDetails = $column;
         $field->parseDBType($dbType); //, $column); TODO: handle column param
         $field->parseHtmlInput($htmlType);
 
@@ -279,12 +264,13 @@ class TableFieldsGenerator
     private function generateNumberInput($column, $dbType)
     {
         $field = new GeneratorField();
-        $field->name = $column->getName();
-        $field->parseDBType($dbType.','.$column->getPrecision().','.$column->getScale());
+        $field->name = $column['name'];
+        $length = get_field_length($column['type']);
+        $field->parseDBType($dbType . ',' . get_field_precision($length) . ',' . get_field_scale($length));
         $field->htmlType = 'number';
 
         if ($dbType === 'decimal') {
-            $field->numberDecimalPoints = $column->getScale();
+            $field->numberDecimalPoints = explode(',', $length)[1];
         }
 
         return $this->checkForPrimary($field);
@@ -306,25 +292,27 @@ class TableFieldsGenerator
      */
     public function prepareForeignKeys()
     {
-        $tables = $this->schemaManager->listTables();
+        $tables = Schema::getTables();
 
         $fields = [];
 
         foreach ($tables as $table) {
-            $primaryKey = $table->getPrimaryKey();
-            if ($primaryKey) {
-                $primaryKey = $primaryKey->getColumns()[0];
+            $primaryKey = '';
+            foreach (Schema::getIndexes($table['name']) as $index) {
+                if ($index['primary']) {
+                    $primaryKey = $index['columns'][0];
+                }
             }
             $formattedForeignKeys = [];
-            $tableForeignKeys = $table->getForeignKeys();
+            $tableForeignKeys = Schema::getForeignKeys($table['name']);
             foreach ($tableForeignKeys as $tableForeignKey) {
                 $generatorForeignKey = new GeneratorForeignKey();
-                $generatorForeignKey->name = $tableForeignKey->getName();
-                $generatorForeignKey->localField = $tableForeignKey->getLocalColumns()[0];
-                $generatorForeignKey->foreignField = $tableForeignKey->getForeignColumns()[0];
-                $generatorForeignKey->foreignTable = $tableForeignKey->getForeignTableName();
-                $generatorForeignKey->onUpdate = $tableForeignKey->onUpdate();
-                $generatorForeignKey->onDelete = $tableForeignKey->onDelete();
+                $generatorForeignKey->name = $tableForeignKey['name'];
+                $generatorForeignKey->localField = $tableForeignKey['columns'][0];
+                $generatorForeignKey->foreignField = $tableForeignKey['foreign_columns'][0];
+                $generatorForeignKey->foreignTable = $tableForeignKey['foreign_table'];
+                $generatorForeignKey->onUpdate = $tableForeignKey['on_update'];
+                $generatorForeignKey->onDelete = $tableForeignKey['on_delete'];
 
                 $formattedForeignKeys[] = $generatorForeignKey;
             }
@@ -333,7 +321,7 @@ class TableFieldsGenerator
             $generatorTable->primaryKey = $primaryKey;
             $generatorTable->foreignKeys = $formattedForeignKeys;
 
-            $fields[$table->getName()] = $generatorTable;
+            $fields[$table['name']] = $generatorTable;
         }
 
         return $fields;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -74,3 +74,27 @@ if (!function_exists('create_resource_route_names')) {
         return $result;
     }
 }
+
+if (!function_exists('get_field_length')) {
+    function get_field_length($type): string
+    {
+        preg_match('/\(\s*(\d+(?:,\s*\d+)*)\s*\)/', $type, $matches);
+        return $matches[1] ?? 0;
+    }
+}
+
+if (!function_exists('get_field_precision')) {
+    function get_field_precision($length): int
+    {
+        $precision = explode(',', $length);
+        return $precision[0] ?? 0;
+    }
+}
+
+if (!function_exists('get_field_scale')) {
+    function get_field_scale($length): int
+    {
+        $precision = explode(',', $length);
+        return $precision[1] ?? 0;
+    }
+}

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -79,6 +79,7 @@ if (!function_exists('get_field_length')) {
     function get_field_length($type): string
     {
         preg_match('/\(\s*(\d+(?:,\s*\d+)*)\s*\)/', $type, $matches);
+
         return $matches[1] ?? 0;
     }
 }
@@ -87,6 +88,7 @@ if (!function_exists('get_field_precision')) {
     function get_field_precision($length): int
     {
         $precision = explode(',', $length);
+
         return $precision[0] ?? 0;
     }
 }
@@ -95,6 +97,7 @@ if (!function_exists('get_field_scale')) {
     function get_field_scale($length): int
     {
         $precision = explode(',', $length);
+
         return $precision[1] ?? 0;
     }
 }


### PR DESCRIPTION
These changes ensure that the package works with version 11 of Laravel without doctrine support, doctrine would provide us with a much more friendly interface to use the database mapping and its tables, but as this package was removed I made this small change ( which didn't look very pretty but is functional), I intend to adjust the methods so that get/set methods can be used instead of direct queries to the arrays, but for now this is what I could do so that my new project can move forward.

If you want to use the fork until the people responsible for the project approve this PR, here's how to use it
```
{
     "repositories": [
         {
             "type": "vcs",
             "url": "git@github.com:fernandopiovezan1/laravel-generator.git"
         }
     ]
}
```
```
{
     "require": {
         "infyomlabs/laravel-generator": "dev-l11-compability-without-doctrine",
     }
}
```

Thanks to @laravel-shift for the adjustments to the dependencies, as I have already updated this version. #1098 